### PR TITLE
add releases page - WIP

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -49,6 +49,7 @@ Distributed application delivery across many clusters and the ability to deliver
 {{< icon "gdoc_github" >}} {{< button size="small" href="https://github.com/open-cluster-management" >}}GitHub{{< /button >}}
 {{< icon "gdoc_heart" >}} {{< button size="small" relref="community/resource" >}}Join the Community{{< /button >}}
 {{< icon "gdoc_git" >}} {{< button size="small" relref="contribute/contribute" >}}Contribute{{< /button >}}
+{{< icon "gdoc_download" >}} {{< button size="small" relref="community/releases" >}}Releases{{< /button >}}
 
 {{< icon "gdoc_person" >}} {{< button size="small" href="https://kubernetes.slack.com/archives/C01GE7YSUUF" >}}Slack{{< /button >}}
 {{< icon "gdoc_date" >}} {{< button size="small" href="https://github.com/open-cluster-management/community/projects/1#card-50787258" >}}Meeting{{< /button >}}

--- a/content/community/releases.md
+++ b/content/community/releases.md
@@ -1,0 +1,24 @@
+---
+title: Releases 
+weight: -20
+---
+
+For the benefit of its users, typically projects within Open Cluster Management has a 4-month release cycle.
+
+<!-- spellchecker-disable -->
+
+{{< toc >}}
+
+<!-- spellchecker-enable -->
+
+## Registration
+
+### 0.3.0
+
+## Application
+
+### 0.2.8
+
+## Policy
+
+Coming soon.


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Hi @qiujian16 I am working towards adding a "Releases" page to the website similar to https://submariner.io/community/releases
But we really haven't discuss our upstream release process yet. So from now I put in the community operator hub version for registration (cluster manager, klusterlet) and app subscription operator. 

WDYT? Should I continue with this and populate the releases with some notes?

FYI @juliana-hsu 