### PR TITLE
fix base url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "http://open-cluster-management.github.io"
+baseURL = "http://open-cluster-management.io"
 languageCode = "en-us"
 title = "Open Cluster Management"
 


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

Fix on mobile the website is redirecting to `http://open-cluster-management.github.io` on clicking the top banner.

Maybe we should consider actually decommission that legacy website as well @qiujian16 @gurnben 