### PR TITLE
Prepare kubeconfig with correct format

### DIFF
--- a/content/getting-started/core/register-cluster.md
+++ b/content/getting-started/core/register-cluster.md
@@ -26,6 +26,7 @@ Prepare another Kubernetes cluster to function as the managed cluster. For examp
 kind create cluster --name <managed cluster name> # kind create cluster --name cluster1
 kind get kubeconfig --name <managed cluster name>  --internal > ~/<managed cluster name>-kubeconfig # kind get kubeconfig --name cluster1 --internal > ~/cluster1-kubeconfig
 ```
+If you are using OKD, OpenShift, you will need to prepare a kubeconfig with `certificate-authority-data`, `client-certificate-data` and `client-key-data`. By default, it's located in `auth/kubeconfig` under your installation folder.
 
 ## Install from source
 
@@ -82,6 +83,7 @@ Run `kubectl get managedcluster` again on the hub cluster. You should be able to
 NAME                     HUB ACCEPTED   MANAGED CLUSTER URLS   JOINED   AVAILABLE   AGE
 <managed cluster name>   true           https://localhost      True     True        7m58s
 ```
+If the managed cluster status is not ture, refer to [Troubleshooting](#troubleshooting) to debug on your cluster.
 
 After the managed cluster is registered, test that you can deploy a pod to the managed cluster from the hub cluster. Create a `manifest-work.yaml` as shown in this example:
 
@@ -126,3 +128,27 @@ $ kubectl -n default get pod
 NAME    READY   STATUS    RESTARTS   AGE
 hello   1/1     Running   0          108s
 ```
+
+## Troubleshooting
+* The managed cluster status is not ture.
+
+  For example, checking managedcluster and get below result.
+  ```
+  $ kubectl get managedcluster
+  NAME                   HUB ACCEPTED   MANAGED CLUSTER URLS   JOINED   AVAILABLE   AGE
+  <managed cluster name> true           https://localhost               Unknown     46m
+  ```
+  There are many reasons for this problem. You can use below commands to get more debug info. If the provided info can't help, please log an issue to us.
+
+  On the hub cluster, check the managedcluster status.
+  ```
+  kubectl get managedcluster <managed cluster name> -oyaml # kubectl get managedcluster cluster1 -oyaml
+  ```
+  On the hub cluster, check the lease status.
+  ```
+  kubectl get lease -n <managed cluster name> # kubectl get lease -n cluster1
+  ```
+  On the managed cluster, check the klusterlet status.
+  ```
+  kubectl get klusterlet -o yaml
+  ```


### PR DESCRIPTION
If managed clusters are OKD or OpenShift, the kubeconfig should contain `certificate-authority-data`, `client-certificate-data` and `client-key-data`, or the managed cluster registration will fail with below error.
```
# kubectl  get klusterlet -o yaml
... 
    - lastTransitionTime: "2021-07-02T02:15:42Z"
      message: 'Failed to create &SelfSubjectAccessReview{ObjectMeta:{      0 0001-01-01
        00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []  []},Spec:SelfSubjectAccessReviewSpec{ResourceAttributes:&ResourceAttributes{Namespace:,Verb:get,Group:certificates.k8s.io,Version:,Resource:certificatesigningrequests,Subresource:,Name:,},NonResourceAttributes:nil,},Status:SubjectAccessReviewStatus{Allowed:false,Reason:,EvaluationError:,Denied:false,},}
        with hub config secret "open-cluster-management-agent" "hub-kubeconfig-secret":
        Post "https://api.qhaoo.dev05.red-chesterfield.com:6443/apis/authorization.k8s.io/v1/selfsubjectaccessreviews":
        x509: certificate signed by unknown authority'
      reason: HubKubeConfigError
      status: "True"
      type: KlusterletRegistrationDegraded
    - lastTransitionTime: "2021-07-02T02:15:42Z"
      message: 'Failed to create &SelfSubjectAccessReview{ObjectMeta:{      0 0001-01-01
        00:00:00 +0000 UTC <nil> <nil> map[] map[] [] []  []},Spec:SelfSubjectAccessReviewSpec{ResourceAttributes:&ResourceAttributes{Namespace:cluster1,Verb:create,Group:,Version:,Resource:events,Subresource:,Name:,},NonResourceAttributes:nil,},Status:SubjectAccessReviewStatus{Allowed:false,Reason:,EvaluationError:,Denied:false,},}
        with hub config secret "open-cluster-management-agent" "hub-kubeconfig-secret":
        Post "https://api.qhaoo.dev05.red-chesterfield.com:6443/apis/authorization.k8s.io/v1/selfsubjectaccessreviews":
        x509: certificate signed by unknown authority'
      reason: HubKubeConfigError
      status: "True"
      type: KlusterletWorkDegraded
```