### PR TITLE
set common env and reduce the kube context switch.

### DIFF
--- a/content/getting-started/core/cluster-manager.md
+++ b/content/getting-started/core/cluster-manager.md
@@ -25,12 +25,20 @@ If you are running OS X, you'll also need to install `gnu-sed`:
 brew install gnu-sed
 ```
 
-To create the hub cluster with `kind`, run:
+Set the following environment variable that will be used throughout to simplify the instructions:
 
 ```Shell
-# kind delete cluster --name hub # if the kind cluster is previously created and can be safely deleted
-kind create cluster --name hub
-kind get kubeconfig --name {your kind cluster name} --internal > ./.hub-kubeconfig # ./.hub-kubeconfig is default value of HUB_KUBECONFIG 
+export HUB_CLUSTER_NAME=<your hub cluster name>             # export HUB_CLUSTER_NAME=hub
+export CTX_HUB_CLUSTER=<your hub cluster context>           # export CTX_HUB_CLUSTER=kind-hub
+export HUB_KUBECONFIG=<your hub cluster kubeconfig file>    # export HUB_KUBECONFIG=~/hub-kubeconfig
+```
+
+Then create the hub cluster with `kind`, run:
+
+```Shell
+# kind delete cluster --name ${HUB_CLUSTER_NAME} # if the kind cluster is previously created and can be safely deleted
+kind create cluster --name ${HUB_CLUSTER_NAME}
+kind get kubeconfig --name ${HUB_CLUSTER_NAME} --internal > ${HUB_KUBECONFIG}
 ```
 
 ## Install from source
@@ -44,7 +52,7 @@ git clone https://github.com/open-cluster-management-io/registration-operator
 Ensure the `kubectl` context is set to point to the hub cluster:
 
 ```Shell
-kubectl config use-context <hub cluster context> # kubectl config use-context kind-hub
+kubectl config use-context ${CTX_HUB_CLUSTER}
 ```
 
 Deploy hub

--- a/content/getting-started/integration/app-lifecycle.md
+++ b/content/getting-started/integration/app-lifecycle.md
@@ -39,37 +39,34 @@ cd multicloud-operators-subscription
 Deploy the subscription operators to the hub cluster.
 
 ```Shell
-$ kubectl config use-context <hub cluster context> # kubectl config use-context kind-hub
+$ kubectl config use-context ${CTX_HUB_CLUSTER}
 $ make deploy-hub
-$ kubectl -n open-cluster-management get deploy  multicloud-operators-subscription
+$ kubectl -n open-cluster-management get deploy multicloud-operators-subscription --context ${CTX_HUB_CLUSTER}
 NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
 multicloud-operators-subscription   1/1     1            1           25s
 ```
 
 Create the `open-cluster-management-agent-addon` namespace on the managed cluster.
 
-```shell
-$ kubectl config use-context <managed cluster context> # kubectl config use-context kind-cluster1
-$ kubectl create ns open-cluster-management-agent-addon
+```Shell
+$ kubectl create ns open-cluster-management-agent-addon --context ${CTX_MANAGED_CLUSTER}
 namespace/open-cluster-management-agent-addon created
 ```
 
-Deploy the subscription add-on on the hub cluster's managed cluster namespace.
+Deploy the subscription add-on in corresponding managed cluster namespace on the hub cluster.
 
-```shell
-$ kubectl config use-context <hub cluster context> # kubectl config use-context kind-hub
-$ export MANAGED_CLUSTER_NAME=<managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
+```Shell
+$ kubectl config use-context ${CTX_HUB_CLUSTER}
 $ make deploy-addon
-$ kubectl -n <managed cluster name> get managedclusteraddon # kubectl -n cluster1 get managedclusteraddon
+$ kubectl -n ${MANAGED_CLUSTER_NAME} get managedclusteraddon # kubectl -n cluster1 get managedclusteraddon
 NAME                  AVAILABLE   DEGRADED   PROGRESSING
 application-manager   True
 ```
 
 Check the the subscription add-on deployment on the managed cluster.
 
-```shell
-$ kubectl config use-context <managed cluster context> # kubectl config use-context kind-cluster1
-$ kubectl -n open-cluster-management-agent-addon get deploy multicloud-operators-subscription
+```Shell
+$ kubectl -n open-cluster-management-agent-addon get deploy multicloud-operators-subscription --context ${CTX_MANAGED_CLUSTER}
 NAME                                READY   UP-TO-DATE   AVAILABLE   AGE
 multicloud-operators-subscription   1/1     1            1           103s
 ```
@@ -79,18 +76,16 @@ multicloud-operators-subscription   1/1     1            1           103s
 After a successful deployment, test the subscription operator with a `helm` subscription. Run the following command:
 
 ```Shell
-kubectl config use-context <hub cluster context> # kubectl config use-context kind-hub
-kubectl apply -f examples/helmrepo-hub-channel
+kubectl apply -f examples/helmrepo-hub-channel --context ${CTX_HUB_CLUSTER}
 ```
 
-After a while, you should see the subscription propagated to the managed cluster and the Helm app installed. By default, when a subscription deploys subscribed applications to target clusters, the applications are deployed to that subscription namespace. To confirm, run the following command:
+After a while, you should see the subscription is propagated to the managed cluster and the Helm app is installed. By default, when a subscribed applications is deployed to the target clusters, the applications are installed in the coresponding subscription namespace. To confirm, run the following command:
 
 ```Shell
-$ kubectl config use-context <managed cluster context> # kubectl config use-context kind-cluster1
-$ kubectl get subscriptions.apps
+$ kubectl get subscriptions.apps --context ${CTX_MANAGED_CLUSTER}
 NAME        STATUS       AGE    LOCAL PLACEMENT   TIME WINDOW
 nginx-sub   Subscribed   107m   true
-$ kubectl get pod
+$ kubectl get pod --context ${CTX_MANAGED_CLUSTER}
 NAME                                                   READY   STATUS      RESTARTS   AGE
 nginx-ingress-47f79-controller-6f495bb5f9-lpv7z        1/1     Running     0          108m
 nginx-ingress-47f79-default-backend-7559599b64-rhwgm   1/1     Running     0          108m

--- a/content/getting-started/integration/policy-controllers.md
+++ b/content/getting-started/integration/policy-controllers.md
@@ -29,8 +29,7 @@ Complete the following procedure to install the configuration policy controller:
 
    ```Shell
    # Configure kubectl to point to the managed cluster
-   export MANAGED_CLUSTER_NAME=<managed cluster name> # export MANAGED_CLUSTER_NAME=cluster1
-   kubectl config use-context <managed cluster context> # kubectl config use-context kind-$MANAGED_CLUSTER_NAME
+   kubectl config use-context ${CTX_MANAGED_CLUSTER}
    
    # Create the namespace
    export MANAGED_NAMESPACE="open-cluster-management-agent-addon"
@@ -65,7 +64,7 @@ Complete the following procedure to install the configuration policy controller:
 1. After a successful deployment, test the policy framework and configuration policy controller with a sample policy. Run the following command:
 
    ```Shell
-   $ kubectl config use-context <hub cluster context> # kubectl config use-context kind-hub
+   $ kubectl config use-context ${CTX_HUB_CLUSTER}
    $ kubectl apply -n default -f https://raw.githubusercontent.com/open-cluster-management/policy-collection/main/stable/CM-Configuration-Management/policy-pod.yaml
    policy.policy.open-cluster-management.io/policy-pod created
    placementbinding.policy.open-cluster-management.io/binding-policy-pod created
@@ -86,8 +85,8 @@ Complete the following procedure to install the configuration policy controller:
    ...
    status:
      decisions:
-     - clusterName: <managed cluster name>
-       clusterNamespace: <managed cluster name>
+     - clusterName: ${MANAGED_CLUSTER_NAME}
+       clusterNamespace: ${MANAGED_CLUSTER_NAME}
    ...
    ```
 
@@ -101,8 +100,7 @@ Complete the following procedure to install the configuration policy controller:
 5. After a few seconds, your policy is propagated to the managed cluster. To confirm, run the following command:
 
    ```Shell
-   $ export MANAGED_CLUSTER_NAME=<managed cluster name> # export MANAGED_CLUSTER_NAME=cluster1
-   $ kubectl config use-context <managed cluster context> # kubectl config use-context kind-$MANAGED_CLUSTER_NAME
+   $ kubectl config use-context ${CTX_MANAGED_CLUSTER}
    $ kubectl get policy -A
    NAMESPACE   NAME                 AGE
    cluster1    default.policy-pod   1m39s

--- a/content/getting-started/integration/policy-framework.md
+++ b/content/getting-started/integration/policy-framework.md
@@ -39,7 +39,7 @@ Complete the following steps to install the policy framework from prebuilt image
 
    ```Shell
    # Configure kubectl to point to the hub cluster
-   kubectl config use-context <hub cluster context> # kubectl config use-context kind-hub
+   kubectl config use-context ${CTX_HUB_CLUSTER}
 
    # Create the namespace
    export HUB_NAMESPACE="open-cluster-management"
@@ -61,7 +61,7 @@ Complete the following steps to install the policy framework from prebuilt image
 2. Ensure the pods are running on the hub with the following command:
 
    ```Shell
-   $ kubectl get pods -n open-cluster-management
+   $ kubectl get pods -n ${HUB_NAMESPACE}
    NAME                                           READY   STATUS    RESTARTS   AGE
    governance-policy-propagator-8c77f7f5f-kthvh   1/1     Running   0          94s
    ```
@@ -71,28 +71,27 @@ Complete the following steps to install the policy framework from prebuilt image
    For `kind` cluster:
 
    ```Shell
-   kind get kubeconfig --name <cluster name> --internal > $PWD/kubeconfig_hub
+   kind get kubeconfig --name ${HUB_CLUSTER_NAME} --internal > ${HUB_KUBECONFIG}
    ```
 
    For non-`kind` clusters:
 
    ```Shell
-   kubectl config view --context=<hub cluster context> --minify --flatten > $PWD/kubeconfig_hub
+   kubectl config view --context=${CTX_HUB_CLUSTER} --minify --flatten > ${HUB_KUBECONFIG}
    ```
 
 4. Deploy the policy synchronization components to the managed cluster. Run the following commands:
 
    ```Shell
    # Configure kubectl to point to the managed cluster
-   export MANAGED_CLUSTER_NAME=<managed cluster name> # export MANAGED_CLUSTER_NAME=cluster1
-   kubectl config use-context <managed cluster context> # kubectl config use-context kind-$MANAGED_CLUSTER_NAME
+   kubectl config use-context ${CTX_MANAGED_CLUSTER}
 
    # Create the namespace
    export MANAGED_NAMESPACE="open-cluster-management-agent-addon"
    kubectl create ns ${MANAGED_NAMESPACE}
 
    # Create the secret to authenticate with the hub
-   kubectl -n ${MANAGED_NAMESPACE} create secret generic hub-kubeconfig --from-file=kubeconfig=$PWD/kubeconfig_hub
+   kubectl -n ${MANAGED_NAMESPACE} create secret generic hub-kubeconfig --from-file=kubeconfig=${HUB_KUBECONFIG}
 
    # Apply the policy CRD
    export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io"

--- a/content/getting-started/quick-start/_index.md
+++ b/content/getting-started/quick-start/_index.md
@@ -54,10 +54,10 @@ Download and extract the [clusteradm binary](https://github.com/open-cluster-man
 
 ### Deploy a klusterlet agent on your managed cluster
 
-1. Run the previously copied `join` command by append the context of your managed cluster to join the hub cluster:
+1. Run the previously copied `join` command by appending the context of your managed cluster to join the hub cluster:
 
    ```Shell
-   clusteradm join --hub-token <token_data> --hub-apiserver https://126.0.0.1:39242 --cluster-name ${MANAGED_CLUSTER_NAME} --context ${CTX_MANAGED_CLUSTER}
+   clusteradm join --context ${CTX_MANAGED_CLUSTER} --hub-token <token_data> --hub-apiserver https://126.0.0.1:39242 --cluster-name ${MANAGED_CLUSTER_NAME}
    ```
 
 ### Accept join request and verify


### PR DESCRIPTION
This PR tries to enhance the document:
- set some common environment variables at the beginning of the whole guideline.
- try to reduce the kube context switch, for example, `clusteradm` support `--context` flag, so we can use that to quickly refer to the expected kube context.
- reduce duplicated environment variable definition, for example, `MANAGED_CLUSTER_NAME` can be exported after the cluster is created by the `kind` command and then it will be reused throughout the guideline.
- fix typo.


Signed-off-by: morvencao <lcao@redhat.com>