### PR TITLE
fix the debug command issue

### DIFF
--- a/content/getting-started/core/register-cluster.md
+++ b/content/getting-started/core/register-cluster.md
@@ -153,7 +153,7 @@ hello   1/1     Running   0          108s
   On the hub cluster, check the managedcluster status.
 
   ```Shell
-  kubectl get managedcluster ${MANAGED_CLUSTER_NAME}--context ${CTX_HUB_CLUSTER} -o yaml
+  kubectl get managedcluster ${MANAGED_CLUSTER_NAME} --context ${CTX_HUB_CLUSTER} -o yaml
   ```
 
   On the hub cluster, check the lease status.


### PR DESCRIPTION
I am try to debug my  `managedcluster` status  `Unknown` issue by this cmd :
```
# kubectl get managedcluster ${MANAGED_CLUSTER_NAME}--context ${CTX_HUB_CLUSTER}
Error from server (NotFound): managedclusters.cluster.open-cluster-management.io "llhu-2--context" not found
Error from server (NotFound): managedclusters.cluster.open-cluster-management.io "kind-llhu-adm" not found
```
It should be cmd issue, Thanks 