### PR TITLE
remove ResourceRatioCPU and ResourceRatioMemory from placement doc

### DIFF
--- a/content/concepts/placement.md
+++ b/content/concepts/placement.md
@@ -85,7 +85,6 @@ spec:
   - `name` is the name of a prioritizer. Below are the valid names:
     - Balance: balance the decisions among the clusters.
     - Steady: ensure the existing decision is stabilized.
-    - ResourceRatioCPU & ResourceRatioMemory: sort clusters based on the allocatable to capacity ratio.
     - ResourceAllocatableCPU & ResourceAllocatableMemory: sort clusters based on the allocatable.
   - `weight` defines the weight of prioritizer. The value must be ranged in [0,10].
     Each prioritizer will calculate an integer score of a cluster in the range of [-100, 100]. The final score of a cluster will be sum(weight * prioritizer_score).


### PR DESCRIPTION
Ref: https://github.com/open-cluster-management-io/api/pull/99

Refer to kubernetes node-allocatable definition https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#node-allocatable, it's a relatively stable value. 
As OCM allocatable is a sum of all the node's allocatable, so using the allocatable to capacity ratio doesn't help so much in scheduling. 
Remove it until we find a better solution. 

Signed-off-by: haoqing0110 <qhao@redhat.com>