### PR TITLE
add copy to clipboard function for code snippets.

### DIFF
--- a/themes/ocmTheme/layouts/partials/page_content.html
+++ b/themes/ocmTheme/layouts/partials/page_content.html
@@ -14,4 +14,5 @@
     </nav>
     <h1>{{ partial "title" . }}</h1>
     {{ partial "content" . }}
+    <script type="text/javascript" src="/clipboard-copy.js"></script>
 </div> 

--- a/themes/ocmTheme/static/clipboard-copy.js
+++ b/themes/ocmTheme/static/clipboard-copy.js
@@ -1,0 +1,53 @@
+(function() {
+    'use strict';
+  
+    // if the current brower doesn't copy command, return instantly.
+    if(!document.queryCommandSupported('copy')) {
+      return;
+    }
+  
+    // showCopyMessage shows copy result
+    function showCopyMessage(el, msg) {
+      el.textContent = msg;
+      setTimeout(function() {
+        el.textContent = "Copy";
+      }, 1000);
+    }
+  
+    // getText get the code snippet content from hugo compiled html node
+    function getText(node) {
+      var selection = window.getSelection();
+      var range = document.createRange();
+      range.selectNodeContents(node);
+      selection.removeAllRanges();
+      selection.addRange(range);
+      return selection;
+    }
+
+    // addCopyBtn adds copy buton to the highlight code snippet container
+    function addCopyBtn(containerElemnt) {
+      var copyBtn = document.createElement("button");
+      copyBtn.className = "clipboard-copy-btn";
+      copyBtn.textContent = "Copy";
+  
+      var codePreElemnt = containerElemnt.firstElementChild;
+      copyBtn.addEventListener('click', function() {
+        try {
+          var selection = getText(codePreElemnt);
+          document.execCommand('copy');
+          selection.removeAllRanges();
+  
+          showCopyMessage(copyBtn, 'Copied!')
+        } catch(e) {
+          console && console.log(e);
+          showCopyMessage(copyBtn, 'Failed!')
+        }
+      });
+
+      containerElemnt.appendChild(copyBtn);
+    }
+  
+    // get the highlight code snippet containers and add copy button
+    var highlightContainers = document.getElementsByClassName('highlight');
+    Array.prototype.forEach.call(highlightContainers, addCopyBtn);
+  })();

--- a/themes/ocmTheme/static/contentpage.css
+++ b/themes/ocmTheme/static/contentpage.css
@@ -16,6 +16,10 @@
         height: auto;
     }
 
+    .highlight {
+        position: relative;
+    }
+
     pre {
         background: #f4f4f4;
         border: 1px solid #ddd;
@@ -31,6 +35,25 @@
         padding: 1em 1.5em;
         display: block;
         word-wrap: break-word;
+    }
+
+    .clipboard-copy-btn {
+        position: absolute;
+        top: 8px;
+        right: 8px;
+        border: 0;
+        border-radius: 4px;
+        padding: 1px;
+        font-size: 0.7em;
+        line-height: 1.8;
+        color: #fff;
+        background-color: #999;
+        min-width: 55px;
+        text-align: center;
+    }
+
+    .clipboard-copy-btn:hover {
+        background-color: #aaa;
     }
     
     body {


### PR DESCRIPTION
resolve: https://github.com/open-cluster-management-io/community/issues/98

**basic idea:**
1. Check if the browser supports the copy, if not, return instantly
2. Get all highlighted code snippet container elements(for the hugo compiled html, the code snippet is in div element with class `highlight`)
3. Add a copy button under the `<pre>` element.
4. Add click handler for the copy button, when the copy button is clicked, copy the text inside the code snippet to the clipboard and show copy result.

![image](https://user-images.githubusercontent.com/5468682/138208554-c396df30-f02f-489f-8fcc-8b26c55d3a7e.png)



Signed-off-by: morvencao <lcao@redhat.com>