### PR TITLE
updating the quick-start doc: deploy a cluster manager step2

### DIFF
--- a/content/en/getting-started/quick-start/_index.md
+++ b/content/en/getting-started/quick-start/_index.md
@@ -117,7 +117,7 @@ Download and extract the clusteradm binary from our [release page](https://githu
 2. Then you can check out the running instances of registration operator by:
 
    ```shell
-   $ kubectl -n open-cluster-management   get pod
+   $ kubectl -n open-cluster-management   get pod   --context ${CTX_HUB_CLUSTER}
    NAME                               READY   STATUS    RESTARTS   AGE
    cluster-manager-695d945d4d-5dn8k   1/1     Running   0          19d
    ```
@@ -126,7 +126,7 @@ Download and extract the clusteradm binary from our [release page](https://githu
    the following command:
 
    ```shell
-   $ kubectl -n open-cluster-management-hub   get pod
+   $ kubectl -n open-cluster-management-hub   get pod   --context ${CTX_HUB_CLUSTER}
    NAME                               READY   STATUS    RESTARTS   AGE
    cluster-manager-placement-controller-857f8f7654-x7sfz      1/1     Running   0          19d
    cluster-manager-registration-controller-85b6bd784f-jbg8s   1/1     Running   0          19d
@@ -139,7 +139,7 @@ Download and extract the clusteradm binary from our [release page](https://githu
    named `clustermanager`:
 
    ```shell
-   $ kubectl get clustermanager cluster-manager -o yaml
+   $ kubectl get clustermanager cluster-manager -o yaml   --context ${CTX_HUB_CLUSTER}
    ```
 
 ### Deploy a klusterlet agent on your managed cluster


### PR DESCRIPTION
While following the quick-start step-by-step, i got a wrong output in  _Deploy a cluster manager on your hub cluster_ https://open-cluster-management.io/getting-started/quick-start/#deploy-a-cluster-manager-on-your-hub-cluster  at step 2 checking out the running instances. 

found that the reason is i'm using the context "kind-cluster1" while running the command `$ kubectl -n open-cluster-management   get pod` ,which means that i'm in the wrong context. (while i created a new kind cluster, the context will be automatically change to the new created one, and in the quick-start, we create "cluster1" after "hub". So i'm running the command in "cluster1", surely i can't get the right output)

in my opinion, set the `--context` option explicitly to these commands will make it easier for beginners.  