### PR TITLE
Adopt FOSSA scan.

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,18 @@
+name: FOSSA License Scan
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+jobs:
+  fossa-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Run FOSSA Scan
+        uses: fossas/fossa-action@v1
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Signed-off-by: Mike Ng <ming@redhat.com>

A branch PR instead of a fork PR because the workflow needs to access the secret values which doesn't work on fork PRs.