### PR TITLE
Add Go package redirects for GRC

### DIFF
--- a/content/en/config-policy-controller.md
+++ b/content/en/config-policy-controller.md
@@ -1,0 +1,4 @@
+---
+title: Configuration Policy Controller
+layout: config-policy-controller
+---

--- a/content/en/governance-policy-propagator.md
+++ b/content/en/governance-policy-propagator.md
@@ -1,0 +1,4 @@
+---
+title: Governance Policy Propagator
+layout: governance-policy-propagator
+---

--- a/content/en/governance-policy-spec-sync.md
+++ b/content/en/governance-policy-spec-sync.md
@@ -1,0 +1,4 @@
+---
+title: Governance Policy Spec Sync
+layout: governance-policy-spec-sync
+---

--- a/content/en/governance-policy-status-sync.md
+++ b/content/en/governance-policy-status-sync.md
@@ -1,0 +1,4 @@
+---
+title: Governance Policy Status Sync
+layout: governance-policy-status-sync
+---

--- a/content/en/governance-policy-template-sync.md
+++ b/content/en/governance-policy-template-sync.md
@@ -1,0 +1,4 @@
+---
+title: Governance Policy Template Sync
+layout: governance-policy-template-sync
+---

--- a/content/en/ocm-kustomize-generator-plugins.md
+++ b/content/en/ocm-kustomize-generator-plugins.md
@@ -1,0 +1,4 @@
+---
+title: Open Cluster Management Kustomize Generator Plugins
+layout: ocm-kustomize-generator-plugins
+---

--- a/layouts/_default/config-policy-controller.html
+++ b/layouts/_default/config-policy-controller.html
@@ -1,0 +1,4 @@
+<html><head>
+  <meta name="go-import" content="open-cluster-management.io/config-policy-controller git https://github.com/open-cluster-management-io/config-policy-controller">
+  <meta name="go-source" content="open-cluster-management.io/config-policy-controller     https://github.com/open-cluster-management-io/config-policy-controller https://github.com/open-cluster-management-io/config-policy-controller/tree/main{/dir} https://github.com/open-cluster-management-io/config-policy-controller/blob/main{/dir}/{file}#L{line}">
+</head></html>

--- a/layouts/_default/governance-policy-propagator.html
+++ b/layouts/_default/governance-policy-propagator.html
@@ -1,0 +1,4 @@
+<html><head>
+  <meta name="go-import" content="open-cluster-management.io/governance-policy-propagator git https://github.com/open-cluster-management-io/governance-policy-propagator">
+  <meta name="go-source" content="open-cluster-management.io/governance-policy-propagator     https://github.com/open-cluster-management-io/governance-policy-propagator https://github.com/open-cluster-management-io/governance-policy-propagator/tree/main{/dir} https://github.com/open-cluster-management-io/governance-policy-propagator/blob/main{/dir}/{file}#L{line}">
+</head></html>

--- a/layouts/_default/governance-policy-spec-sync.html
+++ b/layouts/_default/governance-policy-spec-sync.html
@@ -1,0 +1,4 @@
+<html><head>
+  <meta name="go-import" content="open-cluster-management.io/governance-policy-spec-sync git https://github.com/open-cluster-management-io/governance-policy-spec-sync">
+  <meta name="go-source" content="open-cluster-management.io/governance-policy-spec-sync     https://github.com/open-cluster-management-io/governance-policy-spec-sync https://github.com/open-cluster-management-io/governance-policy-spec-sync/tree/main{/dir} https://github.com/open-cluster-management-io/governance-policy-spec-sync/blob/main{/dir}/{file}#L{line}">
+</head></html>

--- a/layouts/_default/governance-policy-status-sync.html
+++ b/layouts/_default/governance-policy-status-sync.html
@@ -1,0 +1,4 @@
+<html><head>
+  <meta name="go-import" content="open-cluster-management.io/governance-policy-status-sync git https://github.com/open-cluster-management-io/governance-policy-status-sync">
+  <meta name="go-source" content="open-cluster-management.io/governance-policy-status-sync     https://github.com/open-cluster-management-io/governance-policy-status-sync https://github.com/open-cluster-management-io/governance-policy-status-sync/tree/main{/dir} https://github.com/open-cluster-management-io/governance-policy-status-sync/blob/main{/dir}/{file}#L{line}">
+</head></html>

--- a/layouts/_default/governance-policy-template-sync.html
+++ b/layouts/_default/governance-policy-template-sync.html
@@ -1,0 +1,4 @@
+<html><head>
+  <meta name="go-import" content="open-cluster-management.io/governance-policy-template-sync git https://github.com/open-cluster-management-io/governance-policy-template-sync">
+  <meta name="go-source" content="open-cluster-management.io/governance-policy-template-sync     https://github.com/open-cluster-management-io/governance-policy-template-sync https://github.com/open-cluster-management-io/governance-policy-template-sync/tree/main{/dir} https://github.com/open-cluster-management-io/governance-policy-template-sync/blob/main{/dir}/{file}#L{line}">
+</head></html>

--- a/layouts/_default/ocm-kustomize-generator-plugins.html
+++ b/layouts/_default/ocm-kustomize-generator-plugins.html
@@ -1,0 +1,4 @@
+<html><head>
+  <meta name="go-import" content="open-cluster-management.io/ocm-kustomize-generator-plugins git https://github.com/open-cluster-management-io/ocm-kustomize-generator-plugins">
+  <meta name="go-source" content="open-cluster-management.io/ocm-kustomize-generator-plugins     https://github.com/open-cluster-management-io/ocm-kustomize-generator-plugins https://github.com/open-cluster-management-io/ocm-kustomize-generator-plugins/tree/main{/dir} https://github.com/open-cluster-management-io/ocm-kustomize-generator-plugins/blob/main{/dir}/{file}#L{line}">
+</head></html>

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -26,4 +26,22 @@
     <url>
         <loc>http://open-cluster-management.io/managed-serviceaccount?go-get=1</loc>
     </url>
+    <url>
+        <loc>http://open-cluster-management.io/config-policy-controller?go-get=1</loc>
+    </url>
+    <url>
+        <loc>http://open-cluster-management.io/governance-policy-propagator?go-get=1</loc>
+    </url>
+    <url>
+        <loc>http://open-cluster-management.io/governance-policy-spec-sync?go-get=1</loc>
+    </url>
+    <url>
+        <loc>http://open-cluster-management.io/governance-policy-status-sync?go-get=1</loc>
+    </url>
+    <url>
+        <loc>http://open-cluster-management.io/governance-policy-template-sync?go-get=1</loc>
+    </url>
+    <url>
+        <loc>http://open-cluster-management.io/ocm-kustomize-generator-plugins?go-get=1</loc>
+    </url>
 </urlset>


### PR DESCRIPTION
We're going to update all of our repositories to use the `open-cluster-management.io` domains in the community.

- https://github.com/open-cluster-management/backlog/issues/18572