### PR TITLE
Remove gurnben as reviewer.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,4 +6,3 @@ approvers:
 reviewers:
 - qiujian16
 - mikeshng
-- gurnben


### PR DESCRIPTION
I would like the bot to not pick @gurnben as the reviewer for PRs.

Not including in this PR but I feel like @yue9944882 should be added as approver and reviewer in this file. What do you think @yue9944882 ?

Signed-off-by: Mike Ng <ming@redhat.com>