### PR TITLE
The managed cluster namespace is no longer created by sync controllers

### DIFF
--- a/content/en/getting-started/integration/policy-framework.md
+++ b/content/en/getting-started/integration/policy-framework.md
@@ -144,8 +144,9 @@ governance-policy-propagator-8c77f7f5f-kthvh   1/1     Running   0          94s
    export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io"
    kubectl apply -f ${GIT_PATH}/governance-policy-propagator/main/deploy/crds/policy.open-cluster-management.io_policies.yaml
 
-   # Set the managed cluster name
+   # Set the managed cluster name and create the namespace
    export MANAGED_CLUSTER_NAME=cluster1
+   kubectl create ns ${MANAGED_CLUSTER_NAME}
 
    # Deploy the spec synchronization component
    export COMPONENT="governance-policy-spec-sync"


### PR DESCRIPTION
The policy add on controller will take care of creating the managed
cluster namespace.  It will be integrated into this flow in the
future to automatically create the managed cluster namespace.  For now
we need to include creation of the namespace in the procedure here.

Signed-off-by: Gus Parvin <gparvin@redhat.com>