### PR TITLE
docs: fix clusteradm clusterset command syntax

### DIFF
--- a/content/en/concepts/managedclusterset.md
+++ b/content/en/concepts/managedclusterset.md
@@ -57,7 +57,7 @@ member clusters to the set.
 Running the following command to add a cluster to the set:
 
 ```shell
-$ clusteradm clusterset add example-clusterset --clusters managed1
+$ clusteradm clusterset set example-clusterset --clusters managed1
 $ clusteradm get clustersets
 NAME                BOUND NAMESPACES    STATUS
 example-clusterset                      1 ManagedCluster selected
@@ -164,7 +164,7 @@ For easier management, we introduce a ManagedClusterSet called `default`.
 A `default` ManagedClusterSet will be automatically created initially. Any clusters not specifying a ManagedClusterSet will be added into the `default`. 
 The user can move the cluster from the default clusterset to another clusterset using the command:
 ```
-clusteradm clusterset add target-clusterset --clusters cluster-name
+clusteradm clusterset set target-clusterset --clusters cluster-name
 ```
 
 `default` clusterset is an alpha feature that can be disabled by disabling the feature gate in registration controller as:

--- a/content/zh/concepts/managedclusterset.md
+++ b/content/zh/concepts/managedclusterset.md
@@ -57,7 +57,7 @@ member clusters to the set.
 Running the following command to add a cluster to the set:
 
 ```shell
-$ clusteradm clusterset add example-clusterset --clusters managed1
+$ clusteradm clusterset set example-clusterset --clusters managed1
 $ clusteradm get clustersets
 NAME                BOUND NAMESPACES    STATUS
 example-clusterset                      1 ManagedCluster selected
@@ -164,7 +164,7 @@ For easier management, we introduce a ManagedClusterSet called `default`.
 A `default` ManagedClusterSet will be automatically created initially. Any clusters not specifying a ManagedClusterSet will be added into the `default`. 
 The user can move the cluster from the default clusterset to another clusterset using the command:
 ```
-clusteradm clusterset add target-clusterset --clusters cluster-name
+clusteradm clusterset set target-clusterset --clusters cluster-name
 ```
 
 `default` clusterset is an alpha feature that can be disabled by disabling the feature gate in registration controller as:


### PR DESCRIPTION
The [documentation](https://open-cluster-management.io/concepts/managedclusterset/) specifies an incorrect syntax for the `clusteradm` command

Old syntax: ` clusteradm clusterset add`
New syntax: `clusteradm clusterset set`

```
clusteradm version
client		version	:v0.2.0
server release	version	:v1.23.4
```