### PR TITLE
Redefine environment variables from other pages

### DIFF
--- a/content/en/getting-started/integration/policy-controllers.md
+++ b/content/en/getting-started/integration/policy-controllers.md
@@ -31,6 +31,11 @@ Complete the following procedure to install the configuration policy controller:
 1. Deploy the `config-policy-controller` to the managed cluster with the following commands:
 
    ```Shell
+   # The context name of the clusters in your kubeconfig
+   # If the clusters are created by KinD, then the context name will the follow the pattern "kind-<cluster name>".
+   export CTX_HUB_CLUSTER=<your hub cluster context>           # export CTX_HUB_CLUSTER=kind-hub
+   export CTX_MANAGED_CLUSTER=<your managed cluster context>   # export CTX_MANAGED_CLUSTER=kind-cluster1
+
    # Configure kubectl to point to the managed cluster
    kubectl config use-context ${CTX_MANAGED_CLUSTER}
 
@@ -42,6 +47,9 @@ Complete the following procedure to install the configuration policy controller:
    export COMPONENT="config-policy-controller"
    export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/${COMPONENT}/main/deploy"
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_configurationpolicies.yaml
+
+   # Set the managed cluster name
+   export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
 
    # Deploy the controller
    kubectl apply -f ${GIT_PATH}/operator.yaml -n ${MANAGED_NAMESPACE}

--- a/content/en/getting-started/integration/policy-framework.md
+++ b/content/en/getting-started/integration/policy-framework.md
@@ -231,6 +231,11 @@ more details see the
 Deploy the policy framework controllers to the hub cluster:
 
 ```Shell
+# The context name of the clusters in your kubeconfig
+# If the clusters are created by KinD, then the context name will the follow the pattern "kind-<cluster name>".
+export CTX_HUB_CLUSTER=<your hub cluster context>           # export CTX_HUB_CLUSTER=kind-hub
+export CTX_MANAGED_CLUSTER=<your managed cluster context>   # export CTX_MANAGED_CLUSTER=kind-cluster1
+
 # Configure kubectl to point to the hub cluster
 kubectl config use-context ${CTX_HUB_CLUSTER}
 
@@ -327,7 +332,7 @@ governance-policy-propagator-8c77f7f5f-kthvh   1/1     Running   0          94s
    kubectl apply -f ${GIT_PATH}/governance-policy-propagator/main/deploy/crds/policy.open-cluster-management.io_policies.yaml
 
    # Set the managed cluster name and create the namespace
-   export MANAGED_CLUSTER_NAME=cluster1
+   export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
    kubectl create ns ${MANAGED_CLUSTER_NAME}
 
    # Deploy the spec synchronization component

--- a/content/zh/getting-started/integration/policy-controllers.md
+++ b/content/zh/getting-started/integration/policy-controllers.md
@@ -31,6 +31,11 @@ Complete the following procedure to install the configuration policy controller:
 1. Deploy the `config-policy-controller` to the managed cluster with the following commands:
 
    ```Shell
+   # The context name of the clusters in your kubeconfig
+   # If the clusters are created by KinD, then the context name will the follow the pattern "kind-<cluster name>".
+   export CTX_HUB_CLUSTER=<your hub cluster context>           # export CTX_HUB_CLUSTER=kind-hub
+   export CTX_MANAGED_CLUSTER=<your managed cluster context>   # export CTX_MANAGED_CLUSTER=kind-cluster1
+
    # Configure kubectl to point to the managed cluster
    kubectl config use-context ${CTX_MANAGED_CLUSTER}
 
@@ -42,6 +47,9 @@ Complete the following procedure to install the configuration policy controller:
    export COMPONENT="config-policy-controller"
    export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/${COMPONENT}/main/deploy"
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_configurationpolicies.yaml
+
+   # Set the managed cluster name
+   export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
 
    # Deploy the controller
    kubectl apply -f ${GIT_PATH}/operator.yaml -n ${MANAGED_NAMESPACE}

--- a/content/zh/getting-started/integration/policy-framework.md
+++ b/content/zh/getting-started/integration/policy-framework.md
@@ -231,6 +231,11 @@ more details see the
 Deploy the policy framework controllers to the hub cluster:
 
 ```Shell
+# The context name of the clusters in your kubeconfig
+# If the clusters are created by KinD, then the context name will the follow the pattern "kind-<cluster name>".
+export CTX_HUB_CLUSTER=<your hub cluster context>           # export CTX_HUB_CLUSTER=kind-hub
+export CTX_MANAGED_CLUSTER=<your managed cluster context>   # export CTX_MANAGED_CLUSTER=kind-cluster1
+
 # Configure kubectl to point to the hub cluster
 kubectl config use-context ${CTX_HUB_CLUSTER}
 
@@ -327,7 +332,7 @@ governance-policy-propagator-8c77f7f5f-kthvh   1/1     Running   0          94s
    kubectl apply -f ${GIT_PATH}/governance-policy-propagator/main/deploy/crds/policy.open-cluster-management.io_policies.yaml
 
    # Set the managed cluster name and create the namespace
-   export MANAGED_CLUSTER_NAME=cluster1
+   export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
    kubectl create ns ${MANAGED_CLUSTER_NAME}
 
    # Deploy the spec synchronization component


### PR DESCRIPTION
The Policy installation tutorial seems to assume that you start the OCM
installation in the quick start and then progress to the Policy Framework
and then the Policy Controllers in one terminal session. This isn't
always the case, so redefining the required environment variables makes
this clearer.