### PR TITLE
Fix the Policy addon installation instructions

### DIFF
--- a/content/en/getting-started/integration/policy-controllers.md
+++ b/content/en/getting-started/integration/policy-controllers.md
@@ -38,7 +38,7 @@ more details see the
 
    ```Shell
    # Deploy the configuration policy controller
-   clusteradm addon enable addon --names config-policy-controller --clusters <cluster_name> --context ${CTX_MANAGED_CLUSTER}
+   clusteradm addon enable addon --names config-policy-controller --clusters <cluster_name> --context ${CTX_HUB_CLUSTER}
    ```
 
 2. Ensure the pod is running on the managed cluster with the following command:

--- a/content/en/getting-started/integration/policy-framework.md
+++ b/content/en/getting-started/integration/policy-framework.md
@@ -154,7 +154,7 @@ more details see the
    To deploy the synchronization components to a managed cluster:
 
    ```Shell
-   clusteradm addon enable --names governance-policy-framework --clusters <cluster_name> --context ${CTX_MANAGED_CLUSTER}
+   clusteradm addon enable --names governance-policy-framework --clusters <cluster_name> --context ${CTX_HUB_CLUSTER}
    ```
 
 2. Verify that the pod is running on the managed cluster with the following command:

--- a/content/zh/getting-started/integration/policy-controllers.md
+++ b/content/zh/getting-started/integration/policy-controllers.md
@@ -38,7 +38,7 @@ more details see the
 
    ```Shell
    # Deploy the configuration policy controller
-   clusteradm addon enable addon --names config-policy-controller --clusters <cluster_name> --context ${CTX_MANAGED_CLUSTER}
+   clusteradm addon enable addon --names config-policy-controller --clusters <cluster_name> --context ${CTX_HUB_CLUSTER}
    ```
 
 2. Ensure the pod is running on the managed cluster with the following command:

--- a/content/zh/getting-started/integration/policy-framework.md
+++ b/content/zh/getting-started/integration/policy-framework.md
@@ -154,7 +154,7 @@ more details see the
    To deploy the synchronization components to a managed cluster:
 
    ```Shell
-   clusteradm addon enable --names governance-policy-framework --clusters <cluster_name> --context ${CTX_MANAGED_CLUSTER}
+   clusteradm addon enable --names governance-policy-framework --clusters <cluster_name> --context ${CTX_HUB_CLUSTER}
    ```
 
 2. Verify that the pod is running on the managed cluster with the following command:


### PR DESCRIPTION
The ManagedClusterAddOn objects must be deployed on the Hub for the
Policy Addon controller to create the correct ManifestWork objects.