### PR TITLE
Add limitation of Kubernetes distributions

### DIFF
--- a/content/en/getting-started/installation/start-the-control-plane.md
+++ b/content/en/getting-started/installation/start-the-control-plane.md
@@ -14,6 +14,8 @@ weight: 1
 - The hub cluster should be `v1.19+`.
   (To run on hub cluster version between \[`v1.16`, `v1.18`\],
   please manually enable feature gate "V1beta1CSRAPICompatibility").
+- Currently the bootstrap process relies on client authentication via CSR. Therefore, Kubernetes distributions that don't support it can't be used as the hub.
+For example: [EKS](https://github.com/aws/containers-roadmap/issues/1856).
 - Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
 
 ## Install clusteradm CLI tool


### PR DESCRIPTION
close https://github.com/open-cluster-management-io/open-cluster-management-io.github.io/issues/328

I decided to write this in the "Prerequisite" section of the "Start the control plane" page.
I note below the approach I didn't adopt.

- Create a new page called "Supported Kubernetes Distributions".
Given the number of Kubernetes distributions, this seemed premature.

- "Kind is used for E2E testing and is 'supported' in that regard."
This is probably an unnecessary statement since few people create products with Kind(It's mainly for testing).
But if OCM is well tested in OpenShift (is it?) I think we can state "OCM is tested in OpenShift and Kind".

- "EKS support is ongoing."
There is some work toward this, but it seems to have stalled a bit.
https://github.com/open-cluster-management-io/enhancements/pull/69