### PR TITLE
Update links point to the repo ocm.

### DIFF
--- a/content/en/concepts/architecture.md
+++ b/content/en/concepts/architecture.md
@@ -13,54 +13,54 @@ This page is an overview of open cluster management.
 
 ## Overview
 
-__Open Cluster Management__ (OCM) is a powerful, modular, extensible platform 
-for Kubernetes multi-cluster orchestration. Learning from the past failing 
-lesson of building Kubernetes federation systems in the Kubernetes community, 
+__Open Cluster Management__ (OCM) is a powerful, modular, extensible platform
+for Kubernetes multi-cluster orchestration. Learning from the past failing
+lesson of building Kubernetes federation systems in the Kubernetes community,
 in OCM we will be jumping out of the legacy centric, imperative architecture of
-[Kubefed v2](https://github.com/kubernetes-sigs/kubefed) and embracing the 
-"hub-agent" architecture which is identical to the original pattern of 
-"hub-kubelet" from Kubernetes. Hence, intuitively in OCM our multi-cluster 
-control plane is modeled as a "Hub" and on the other hand each of the clusters 
-being managed by the "Hub" will be a "Klusterlet" which is obviously inspired 
-from the original name of "kubelet". Here's a more detailed clarification of 
+[Kubefed v2](https://github.com/kubernetes-sigs/kubefed) and embracing the
+"hub-agent" architecture which is identical to the original pattern of
+"hub-kubelet" from Kubernetes. Hence, intuitively in OCM our multi-cluster
+control plane is modeled as a "Hub" and on the other hand each of the clusters
+being managed by the "Hub" will be a "Klusterlet" which is obviously inspired
+from the original name of "kubelet". Here's a more detailed clarification of
 the two models we will be frequently using throughout the world of OCM:
 
 * __Hub Cluster__: Indicating the cluster that runs the multi-cluster control
-  plane of OCM. Generally the hub cluster is supposed to be a light-weight 
-  Kubernetes cluster hosting merely a few fundamental controllers and services. 
-  
-* __Klusterlet__: Indicating the clusters that being managed by the hub 
-  cluster. Klusterlet might also be called "managed cluster" or "spoke cluster". The 
+  plane of OCM. Generally the hub cluster is supposed to be a light-weight
+  Kubernetes cluster hosting merely a few fundamental controllers and services.
+
+* __Klusterlet__: Indicating the clusters that being managed by the hub
+  cluster. Klusterlet might also be called "managed cluster" or "spoke cluster". The
   klusterlet is supposed to actively __pulling__ the latest prescriptions from
   the hub cluster and consistently reconciles the physical Kubernetes cluster
   to the expected state.
-  
+
 ### "Hub-spoke" architecture
 
-Benefiting from the merit of ["hub-spoke"](https://en.wikipedia.org/wiki/Spoke%E2%80%93hub_distribution_paradigm) architecture, in abstraction we 
-are de-coupling most of the multi-cluster operations generally into 
-(1) computation/decision and (2) execution, and the actual execution against 
+Benefiting from the merit of ["hub-spoke"](https://en.wikipedia.org/wiki/Spoke%E2%80%93hub_distribution_paradigm) architecture, in abstraction we
+are de-coupling most of the multi-cluster operations generally into
+(1) computation/decision and (2) execution, and the actual execution against
 the target cluster will be completely off-loaded into the managed cluster. The
-hub cluster won't directly request against the real clusters, instead it 
-just persists its prescriptions declaratively for each cluster, and the 
+hub cluster won't directly request against the real clusters, instead it
+just persists its prescriptions declaratively for each cluster, and the
 klusterlet will be actively pulling the prescriptions from the hub and doing
 the execution. Hence, the burden of the hub cluster will be greatly relieved
-because the hub cluster doesn't need to either deal with flooding events from 
-the managed clusters or be buried in sending requests against the clusters. 
+because the hub cluster doesn't need to either deal with flooding events from
+the managed clusters or be buried in sending requests against the clusters.
 Imagine in a world where there's no kubelet in Kubernetes and its control plane
-is directly operating the container daemons, it will be extremely hard for a 
+is directly operating the container daemons, it will be extremely hard for a
 centric controller to manage a cluster of 5k+ nodes. Likewise, that's how OCM
-trying to breach the bottleneck of scalability, by dividing and offloading the 
+trying to breach the bottleneck of scalability, by dividing and offloading the
 execution into separated agents. So it's always feasible for a hub cluster to
 accept and manage thousand-ish clusters.
 
 Each klusterlet will be working independently and autonomously, so they have
-a weak dependency to the availability of the hub cluster. If the hub goes down 
-(e.g. during maintenance or network partition) the klusterlet or other OCM 
-agents working in the managed cluster are supposed to keep actively managing 
+a weak dependency to the availability of the hub cluster. If the hub goes down
+(e.g. during maintenance or network partition) the klusterlet or other OCM
+agents working in the managed cluster are supposed to keep actively managing
 the hosting cluster until it re-connects. Additionally if the hub cluster and
-the managed clusters are owned by different admins, it will be easier for the 
-admin of the managed cluster to police the prescriptions from the hub control 
+the managed clusters are owned by different admins, it will be easier for the
+admin of the managed cluster to police the prescriptions from the hub control
 plane because the klusterlet is running as a "white-box" as a pod instance in
 the managed cluster. Upon any accident, the klusterlet admin can quickly cut
 off the connection with the hub cluster without shutting the whole multi-cluster
@@ -72,13 +72,13 @@ control plane down.
 
 
 The "hub-agent" architecture also minimized the requirements in the network
-for registering a new cluster to the hub. Any cluster that can reach the 
-endpoint of the hub cluster will be able to be managed, even a random KinD 
-sandbox cluster on your laptop. That is because the prescriptions are 
-effectively __pulled__ from the hub instead of __pushing__. In addition to 
+for registering a new cluster to the hub. Any cluster that can reach the
+endpoint of the hub cluster will be able to be managed, even a random KinD
+sandbox cluster on your laptop. That is because the prescriptions are
+effectively __pulled__ from the hub instead of __pushing__. In addition to
 that, OCM also provides a [addon](https://open-cluster-management.io/concepts/addon/)
 named ["cluster-proxy"](https://open-cluster-management.io/getting-started/integration/cluster-proxy/)
-which automatically manages a reverse proxy tunnel for proactive access to the 
+which automatically manages a reverse proxy tunnel for proactive access to the
 managed clusters by leveraging on the Kubernetes' subproject [konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/).
 
 
@@ -87,14 +87,14 @@ managed clusters by leveraging on the Kubernetes' subproject [konnectivity](http
 Not only OCM will bring you a fluent user-experience of managing a number of
 clusters on ease, but also it will be equally friendly to further customization
 or second-time development. Every functionality working in OCM is expected to
-be freely-pluggable by modularizing the atomic capability into separated 
-building blocks, except for the mandatory core module named [registration](https://github.com/open-cluster-management-io/registration)
-which is responsible for controlling the lifecycle of a managed controller 
+be freely-pluggable by modularizing the atomic capability into separated
+building blocks, except for the mandatory core module named [registration](https://github.com/open-cluster-management-io/ocm/tree/main/cmd/registration)
+which is responsible for controlling the lifecycle of a managed controller
 and exporting the elementary `ManagedCluster` model.
 
 Another good example surfacing our modularity will be the [placement](https://open-cluster-management.io/concepts/placement/),
-a standalone module focusing at dynamically selecting the proper list of 
-the managed clusters from the user's prescription. You can build any advanced 
+a standalone module focusing at dynamically selecting the proper list of
+the managed clusters from the user's prescription. You can build any advanced
 multi-cluster orchestration on the top of placement, e.g. multi-cluster
 workload re-balancing, multi-cluster helm charts replication, etc. On the
 other hand if you're not satisfied by the current capacities from our placement
@@ -108,13 +108,13 @@ reach out to our community so that we can converge in the future if possible.
 
 ### Cluster registering: "double opt-in handshaking"
 
-Practically the hub cluster and the managed cluster can be owned/maintained 
+Practically the hub cluster and the managed cluster can be owned/maintained
 by different admins, so in OCM we clearly separated the roles and make the
 cluster registration require approval from the both sides defending from unwelcome
 requests. In terms of terminating the registration, the hub admin can kick
 out a registered cluster by denying the rotation of hub cluster's certificate,
 on the other hand from the perspective of a managed cluster's admin, he can
-either brutally deleting the agent instances or revoking the granted RBAC 
+either brutally deleting the agent instances or revoking the granted RBAC
 permissions for the agents. Note that the hub controller will be automatically
 preparing environment for the newly registered cluster and cleaning up neatly
 upon kicking a managed cluster.
@@ -129,25 +129,25 @@ upon kicking a managed cluster.
    <img src="/security-model.png" alt="Security model" style="margin: 0 auto; width: 60%">
 </div>
 
-The worker cluster admin can list and read any managed cluster’s CSR, 
-but those CSR cannot be used to impersonate due to the fact that CSR only 
-contains the certificate. The client authentication requires both the key and certificate. 
+The worker cluster admin can list and read any managed cluster’s CSR,
+but those CSR cannot be used to impersonate due to the fact that CSR only
+contains the certificate. The client authentication requires both the key and certificate.
 The key is stored in each managed cluster, and it will not be transmitted across the network.
 
-The worker cluster admin cannot approve his or her own cluster registration by default. 
-Two separate RBAC rules are needed to approve a cluster registration. 
-The permission to approve the CSR and the permission to accept the managed cluster. 
+The worker cluster admin cannot approve his or her own cluster registration by default.
+Two separate RBAC rules are needed to approve a cluster registration.
+The permission to approve the CSR and the permission to accept the managed cluster.
 Only the cluster admin on hub has both permissions and can accept the cluster registration request.
 The second accept permission is gated by a webhook.
 
-### Cluster namespace 
+### Cluster namespace
 
 Kubernetes has a native soft multi-tenancy isolation in the granularity of
 its namespace resources, so in OCM, for each of the managed cluster we will
 be provisioning a dedicated namespace for the managed cluster and grants
 sufficient RBAC permissions so that the klusterlet can persist some data
 in the hub cluster. This dedicated namespace is the "cluster namespace" which
-is majorly for saving the prescriptions from the hub. e.g. we can create 
+is majorly for saving the prescriptions from the hub. e.g. we can create
 `ManifestWork` in a cluster namespace in order to deploy some resources towards
 the corresponding cluster. Meanwhile, the cluster namespace can also be used
 to save the uploaded stats from the klusterlet e.g. the healthiness of an
@@ -156,8 +156,8 @@ addon, etc.
 ### Addons
 
 Addon is a general concept for the optional, pluggable customization built over
-the extensibility from OCM. It can be a controller in the hub cluster, or just 
-a customized agent in the managed cluster, or even the both collaborating 
+the extensibility from OCM. It can be a controller in the hub cluster, or just
+a customized agent in the managed cluster, or even the both collaborating
 in peers. The addons are expected to implement the `ClusterManagementAddon` or
 `ManagedClusterAddOn` API of which a detailed elaboration can be found [here](https://open-cluster-management.io/concepts/addon/).
 
@@ -165,14 +165,14 @@ in peers. The addons are expected to implement the `ClusterManagementAddon` or
 
 ## Building blocks
 
-The following is a list of commonly-used modules/subprojects that you might 
+The following is a list of commonly-used modules/subprojects that you might
 be interested in the journey of OCM:
 
 ### Registration
 
 The core module of OCM manages the lifecycle of the managed clusters. The
-registration controller in the hub cluster can be intuitively compared to a 
-broker that represents and manages the hub cluster in terms of cluster 
+registration controller in the hub cluster can be intuitively compared to a
+broker that represents and manages the hub cluster in terms of cluster
 registration, while the registration agent working in the managed cluster
 is another broker that represents the managed cluster. After a successful
 registration, the registration controller and agent will also be consistently
@@ -181,41 +181,41 @@ probing each other's healthiness. i.e. the cluster heartbeats.
 
 ### Work
 
-The module for dispatching resources from the hub cluster to the managed 
+The module for dispatching resources from the hub cluster to the managed
 clusters, which can be easily done by writing a `ManifestWork` resource into
 a cluster namespace. See more details about the API [here](https://open-cluster-management.io/concepts/manifestwork/).
 
 ### Placement
 
-Building custom advanced topology across the clusters by either grouping 
-clusters via the labels or the cluster-claims. The placement module is 
+Building custom advanced topology across the clusters by either grouping
+clusters via the labels or the cluster-claims. The placement module is
 completely decoupled from the execution, the output from placement will
 be merely a list of names of the matched clusters in the `PlacementDecision`
-API, so the consumer controller of the decision output can reactively 
+API, so the consumer controller of the decision output can reactively
 discovery the topology or availability change from the managed clusters by
 simply list-watching the decision API.
 
 
 ### Application lifecycle
 
-The _application lifecycle_ defines the processes that are used to manage 
-application resources on your managed clusters. A multi-cluster application 
-uses a Kubernetes specification, but with additional automation of the 
-deployment and lifecycle management of resources to individual clusters. A 
-multi-cluster application allows you to deploy resources on multiple clusters, 
-while maintaining easy-to-reconcile service routes, as well as full control 
+The _application lifecycle_ defines the processes that are used to manage
+application resources on your managed clusters. A multi-cluster application
+uses a Kubernetes specification, but with additional automation of the
+deployment and lifecycle management of resources to individual clusters. A
+multi-cluster application allows you to deploy resources on multiple clusters,
+while maintaining easy-to-reconcile service routes, as well as full control
 of Kubernetes resource updates for all aspects of the application.
 
 ### Governance and risk
 
-_Governance and risk_ is the term used to define the processes that are used 
-to manage security and compliance from the hub cluster. Ensure the security 
+_Governance and risk_ is the term used to define the processes that are used
+to manage security and compliance from the hub cluster. Ensure the security
 of your cluster with the extensible policy framework. After you configure a hub
-cluster and a managed cluster, you can create, modify and delete policies on 
+cluster and a managed cluster, you can create, modify and delete policies on
 the hub and apply policies to the managed clusters.
 
 ### Registration operator
 
 Automating the installation and upgrading of a few built-in modules in OCM. You
-can either deploy the operator standalone or delegate the registration operator 
+can either deploy the operator standalone or delegate the registration operator
 to the operator lifecycle framework.

--- a/content/en/concepts/managedcluster.md
+++ b/content/en/concepts/managedcluster.md
@@ -88,7 +88,7 @@ gracefully with permission and validity under control.
 
 
 Note that the functionality mentioned above are all managed by OCM's
-[registration](https://github.com/open-cluster-management-io/registration)
+[registration](https://github.com/open-cluster-management-io/ocm/tree/main/cmd/registration)
 sub-project, which is the "root dependency" in the OCM world. It includes
 an agent in the managed cluster to register to the hub and a controller in
 the hub cluster to coordinate with the agent.

--- a/content/en/concepts/managedclusterset.md
+++ b/content/en/concepts/managedclusterset.md
@@ -30,9 +30,9 @@ from the Kubernetes SIG-Multicluster. Member clusters in the set are supposed
 to have common/similar attributes e.g. purpose of use, deployed regions, etc.
 
 `ManagedClusterSetBinding` is a namespace-scoped API in the hub cluster to project
-a `ManagedClusterSet` into a certain namespace. Each `ManagedClusterSet` can be 
-managed/administrated by different hub admins, and their RBAC permissions can 
-also be isolated by binding the `ManagedClusterSet` to a "workspace namespace" in 
+a `ManagedClusterSet` into a certain namespace. Each `ManagedClusterSet` can be
+managed/administrated by different hub admins, and their RBAC permissions can
+also be isolated by binding the `ManagedClusterSet` to a "workspace namespace" in
 the hub cluster via `ManagedClusterSetBinding`.
 
 Note that `ManagedClusterSet` and "workspace namespace" has an __M*N__
@@ -43,7 +43,7 @@ relationship:
 - Bind one cluster set to multiple workspace namespace indicates that the
   cluster set can be operated from all the bound namespaces at the same time.
 
-The cluster set admin can flexibly operate the member clusters in the workspace 
+The cluster set admin can flexibly operate the member clusters in the workspace
 namespace using [Placement](../placement) API, etc.
 
 The following picture shows the hierarchies of how the cluster set works:
@@ -74,7 +74,7 @@ $ clusteradm get clustersets
 ```
 
 The newly created cluster set will be empty by default, so we can move on adding
-member clusters to the set. 
+member clusters to the set.
 
 ### Adding a ManagedCluster to a ManagedClusterSet
 
@@ -140,7 +140,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   name: example-clusterset
-spec: 
+spec:
   clusterSelector:
     selectorType: ExclusiveClusterSetLabel
 status:
@@ -159,7 +159,7 @@ metadata:
   name: example-openshift-clusterset
 spec:
   clusterSelector:
-    labelSelector: 
+    labelSelector:
       matchLabels:
         vendor: OpenShift
     selectorType: LabelSelector
@@ -172,7 +172,7 @@ status:
     type: ClusterSetEmpty
 ```
 
-The `ManagedClusterSetBinding` can also be checked by the command 
+The `ManagedClusterSetBinding` can also be checked by the command
 `kubectl get managedclustersetbinding <cluster set name> -n <workspace-namespace> -oyaml`:
 
 ```yaml
@@ -196,7 +196,7 @@ status:
 
 #### Adding member cluster to a clusterset
 
-Adding a new member cluster to a clusterset requires RBAC permission of 
+Adding a new member cluster to a clusterset requires RBAC permission of
 updating the managed cluster and `managedclustersets/join` subresource. We can
 manually apply the following clusterrole to allow a hub user to manipulate
 that clusterset:
@@ -242,23 +242,23 @@ rules:
 
 ## Default ManagedClusterSet
 
-For easier management, we introduce a ManagedClusterSet called `default`. 
-A `default` ManagedClusterSet will be automatically created initially. Any clusters not specifying a ManagedClusterSet will be added into the `default`. 
+For easier management, we introduce a ManagedClusterSet called `default`.
+A `default` ManagedClusterSet will be automatically created initially. Any clusters not specifying a ManagedClusterSet will be added into the `default`.
 The user can move the cluster from the default clusterset to another clusterset using the command:
 ```
 clusteradm clusterset set target-clusterset --clusters cluster-name
 ```
 
 `default` clusterset is an alpha feature that can be disabled by disabling the feature gate in registration controller as:
-[`- "--feature-gates=DefaultClusterSet=false"`](https://github.com/open-cluster-management-io/registration-operator/commit/55bc274d795ad0befc71f05aecd08810a4abfba1#diff-1026afceb1a224783dbf517bc281e71c1640636f5f001338f8185a0b4398b3d9R51) 
+[`- "--feature-gates=DefaultClusterSet=false"`](https://github.com/open-cluster-management-io/ocm/commit/55bc274d795ad0befc71f05aecd08810a4abfba1#diff-1026afceb1a224783dbf517bc281e71c1640636f5f001338f8185a0b4398b3d9R51)
 
 ## Global ManagedClusterSet
 
-For easier management, we also introduce a ManagedClusterSet called `global`. 
+For easier management, we also introduce a ManagedClusterSet called `global`.
 A `global` ManagedClusterSet will be automatically created initially. The `global` ManagedClusterSet include all ManagedClusters.
 
 `global` clusterset is an alpha feature that can be disabled by disabling the feature gate in registration controller as:
-[`- "--feature-gates=DefaultClusterSet=false"`](https://github.com/open-cluster-management-io/registration-operator/commit/55bc274d795ad0befc71f05aecd08810a4abfba1#diff-1026afceb1a224783dbf517bc281e71c1640636f5f001338f8185a0b4398b3d9R51) 
+[`- "--feature-gates=DefaultClusterSet=false"`](https://github.com/open-cluster-management-io/ocm/commit/55bc274d795ad0befc71f05aecd08810a4abfba1#diff-1026afceb1a224783dbf517bc281e71c1640636f5f001338f8185a0b4398b3d9R51)
 
 `global` ManagedClusterSet detail:
 

--- a/content/en/contribute/_index.md
+++ b/content/en/contribute/_index.md
@@ -13,7 +13,7 @@ All contributions are welcome! Open Cluster Management uses the [Apache 2 licens
 
 - Join the [Mailing group](https://groups.google.com/g/open-cluster-management)
 - Attend an upcoming [Community meetings](https://github.com/open-cluster-management-io/community/projects/1)
-- Fork the [repository](https://github.com/open-cluster-management-io) you wish to work on. For example, [API](https://github.com/open-cluster-management-io/api),[Registration](https://github.com/open-cluster-management-io/registration), etc.
+- Fork the [repository](https://github.com/open-cluster-management-io) you wish to work on. For example, [API](https://github.com/open-cluster-management-io/api),[ocm](https://github.com/open-cluster-management-io/ocm), etc.
 - Get started by following the `CONTRIBUTING.md` guide in the repository you wish to work on
 
 ## Get Involved / File a Bug

--- a/content/en/getting-started/installation/start-the-control-plane.md
+++ b/content/en/getting-started/installation/start-the-control-plane.md
@@ -56,7 +56,7 @@ Call `clusteradm init`:
 ```
 
 The `clusteradm init` command installs the
-[registration-operator](https://github.com/open-cluster-management-io/registration-operator)
+[registration-operator](https://github.com/open-cluster-management-io/ocm/tree/main/cmd/registration-operator)
 on the hub cluster, which is responsible for consistently installing
 and upgrading a few core components for the OCM environment.
 
@@ -103,7 +103,7 @@ kubectl get clustermanager cluster-manager -o yaml --context ${CTX_HUB_CLUSTER}
 
 ## Uninstall the OCM from the control plane
 
-Before uninstalling the OCM components from your clusters, please detach the 
+Before uninstalling the OCM components from your clusters, please detach the
 managed cluster from the control plane.
 
 ```shell

--- a/content/zh/blog/registration-deepdive/_index.md
+++ b/content/zh/blog/registration-deepdive/_index.md
@@ -69,7 +69,7 @@ rules:
 
 ## 实现细节
 
-所有认证授权和秘钥管理的代码实现都在[registration](https://github.com/open-cluster-management-io/registration)组件中。大概的流程
+所有认证授权和秘钥管理的代码实现都在[registration](https://github.com/open-cluster-management-io/ocm/tree/main/cmd/registration)组件中。大概的流程
 如下图所示
 
 ![](./assets/registration-process.png)

--- a/content/zh/concepts/architecture.md
+++ b/content/zh/concepts/architecture.md
@@ -19,7 +19,7 @@ __Open Cluster Management__ (OCM) 是用于Kubernetes多集群编排的一个功
 以下是对于两个模型更加详细的解释，我们将在OCM的世界中频繁的使用这两个模型：
 
 * __Hub Cluster__: 表示运行着OCM多集群控制平面的集群。通常hub cluster应该是一个轻量级的Kubernetes集群，仅仅托管着一些基础的控制器和服务。
-  
+
 * __Klusterlet__: 表示由hub cluster管理着的集群，也被称为“managed cluster”或“spoke cluster”。klusterlet应该主动的从hub cluster __拉取__ 最新的处方，并持续将物理的Kubernetes集群调和到预期状态。
 
 ### hub-agent” 架构
@@ -47,7 +47,7 @@ hub cluster的负担将会大大减轻，因为hub cluster既不需要处理来�
 ### 模块化和可扩展性
 
 OCM不仅会给您带来流畅的用户体验，让您轻松管理多个集群，而且对进一步定制或二次开发同样友好。
-OCM中每一个功能，都可以通过将原子能力模块化到单独的构建块中，来实现自由拔插，除了了一个名为[registration](https://github.com/open-cluster-management-io/registration)的强制性核心模块，此模块负责控制managed控制器的生命周期，并导出基本的`ManagedCluster`模型。
+OCM中每一个功能，都可以通过将原子能力模块化到单独的构建块中，来实现自由拔插，除了了一个名为[registration](https://github.com/open-cluster-management-io/ocm/tree/main/cmd/registration)的强制性核心模块，此模块负责控制managed控制器的生命周期，并导出基本的`ManagedCluster`模型。
 
 另一个展示我们模块化能力的好例子是[placement](https://open-cluster-management.io/concepts/placement/)，该独立模块专注于从动态的从用户的处方中，选择合适的managed cluster列表。
 你可以在placement的基础上，构建任何高级的多集群编排方案，比如：多集群工作负载再平衡，多集群helm图表副本等。
@@ -107,7 +107,7 @@ placement模块和执行是完全解耦的，placement的输出结果仅为`Plac
 ### Application lifecycle
 
 __应用生命周期（application lifecycle）__ 定义了用于管理你的managed cluster上应用资源的过程。
-一个多集群应用依然使用Kubernetes规范，但同时具有应用额外的自动化及对各个集群上资源生命周期的管理。 
+一个多集群应用依然使用Kubernetes规范，但同时具有应用额外的自动化及对各个集群上资源生命周期的管理。
 多集群应用允许你在多个集群部署资源，同时维护着易于协调的服务路由，以及对应用各个方面Kubernetes资源更新的完全控制。
 
 ### Governance and risk

--- a/content/zh/concepts/managedcluster.md
+++ b/content/zh/concepts/managedcluster.md
@@ -88,7 +88,7 @@ gracefully with permission and validity under control.
 
 
 Note that the functionality mentioned above are all managed by OCM's
-[registration](https://github.com/open-cluster-management-io/registration)
+[registration](https://github.com/open-cluster-management-io/ocm/tree/main/cmd/registration)
 sub-project, which is the "root dependency" in the OCM world. It includes
 an agent in the managed cluster to register to the hub and a controller in
 the hub cluster to coordinate with the agent.

--- a/content/zh/concepts/managedclusterset.md
+++ b/content/zh/concepts/managedclusterset.md
@@ -30,9 +30,9 @@ from the Kubernetes SIG-Multicluster. Member clusters in the set are supposed
 to have common/similar attributes e.g. purpose of use, deployed regions, etc.
 
 `ManagedClusterSetBinding` is a namespace-scoped API in the hub cluster to project
-a `ManagedClusterSet` into a certain namespace. Each `ManagedClusterSet` can be 
-managed/administrated by different hub admins, and their RBAC permissions can 
-also be isolated by binding the `ManagedClusterSet` to a "workspace namespace" in 
+a `ManagedClusterSet` into a certain namespace. Each `ManagedClusterSet` can be
+managed/administrated by different hub admins, and their RBAC permissions can
+also be isolated by binding the `ManagedClusterSet` to a "workspace namespace" in
 the hub cluster via `ManagedClusterSetBinding`.
 
 Note that `ManagedClusterSet` and "workspace namespace" has an __M*N__
@@ -43,7 +43,7 @@ relationship:
 - Bind one cluster set to multiple workspace namespace indicates that the
   cluster set can be operated from all the bound namespaces at the same time.
 
-The cluster set admin can flexibly operate the member clusters in the workspace 
+The cluster set admin can flexibly operate the member clusters in the workspace
 namespace using [Placement](../placement) API, etc.
 
 The following picture shows the hierarchies of how the cluster set works:
@@ -74,7 +74,7 @@ $ clusteradm get clustersets
 ```
 
 The newly created cluster set will be empty by default, so we can move on adding
-member clusters to the set. 
+member clusters to the set.
 
 ### Adding a ManagedCluster to a ManagedClusterSet
 
@@ -140,7 +140,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSet
 metadata:
   name: example-clusterset
-spec: 
+spec:
   clusterSelector:
     selectorType: ExclusiveClusterSetLabel
 status:
@@ -159,7 +159,7 @@ metadata:
   name: example-openshift-clusterset
 spec:
   clusterSelector:
-    labelSelector: 
+    labelSelector:
       matchLabels:
         vendor: OpenShift
     selectorType: LabelSelector
@@ -172,7 +172,7 @@ status:
     type: ClusterSetEmpty
 ```
 
-The `ManagedClusterSetBinding` can also be checked by the command 
+The `ManagedClusterSetBinding` can also be checked by the command
 `kubectl get managedclustersetbinding <cluster set name> -n <workspace-namespace> -oyaml`:
 
 ```yaml
@@ -196,7 +196,7 @@ status:
 
 #### Adding member cluster to a clusterset
 
-Adding a new member cluster to a clusterset requires RBAC permission of 
+Adding a new member cluster to a clusterset requires RBAC permission of
 updating the managed cluster and `managedclustersets/join` subresource. We can
 manually apply the following clusterrole to allow a hub user to manipulate
 that clusterset:
@@ -242,23 +242,23 @@ rules:
 
 ## Default ManagedClusterSet
 
-For easier management, we introduce a ManagedClusterSet called `default`. 
-A `default` ManagedClusterSet will be automatically created initially. Any clusters not specifying a ManagedClusterSet will be added into the `default`. 
+For easier management, we introduce a ManagedClusterSet called `default`.
+A `default` ManagedClusterSet will be automatically created initially. Any clusters not specifying a ManagedClusterSet will be added into the `default`.
 The user can move the cluster from the default clusterset to another clusterset using the command:
 ```
 clusteradm clusterset set target-clusterset --clusters cluster-name
 ```
 
 `default` clusterset is an alpha feature that can be disabled by disabling the feature gate in registration controller as:
-[`- "--feature-gates=DefaultClusterSet=false"`](https://github.com/open-cluster-management-io/registration-operator/commit/55bc274d795ad0befc71f05aecd08810a4abfba1#diff-1026afceb1a224783dbf517bc281e71c1640636f5f001338f8185a0b4398b3d9R51) 
+[`- "--feature-gates=DefaultClusterSet=false"`](https://github.com/open-cluster-management-io/ocm/commit/55bc274d795ad0befc71f05aecd08810a4abfba1#diff-1026afceb1a224783dbf517bc281e71c1640636f5f001338f8185a0b4398b3d9R51)
 
 ## Global ManagedClusterSet
 
-For easier management, we also introduce a ManagedClusterSet called `global`. 
+For easier management, we also introduce a ManagedClusterSet called `global`.
 A `global` ManagedClusterSet will be automatically created initially. The `global` ManagedClusterSet include all ManagedClusters.
 
 `global` clusterset is an alpha feature that can be disabled by disabling the feature gate in registration controller as:
-[`- "--feature-gates=DefaultClusterSet=false"`](https://github.com/open-cluster-management-io/registration-operator/commit/55bc274d795ad0befc71f05aecd08810a4abfba1#diff-1026afceb1a224783dbf517bc281e71c1640636f5f001338f8185a0b4398b3d9R51) 
+[`- "--feature-gates=DefaultClusterSet=false"`](https://github.com/open-cluster-management-io/ocm/commit/55bc274d795ad0befc71f05aecd08810a4abfba1#diff-1026afceb1a224783dbf517bc281e71c1640636f5f001338f8185a0b4398b3d9R51)
 
 `global` ManagedClusterSet detail:
 

--- a/content/zh/contribute/_index.md
+++ b/content/zh/contribute/_index.md
@@ -13,7 +13,7 @@ All contributions are welcome! Open Cluster Management uses the [Apache 2 licens
 
 - Join the [Mailing group](https://groups.google.com/g/open-cluster-management)
 - Attend an upcoming [Community meetings](https://github.com/open-cluster-management-io/community/projects/1)
-- Fork the [repository](https://github.com/open-cluster-management-io) you wish to work on. For example, [API](https://github.com/open-cluster-management-io/api),[Registration](https://github.com/open-cluster-management-io/registration), etc.
+- Fork the [repository](https://github.com/open-cluster-management-io) you wish to work on. For example, [API](https://github.com/open-cluster-management-io/api),[ocm](https://github.com/open-cluster-management-io/ocm), etc.
 - Get started by following the `CONTRIBUTING.md` guide in the repository you wish to work on
 
 ## Get Involved / File a Bug


### PR DESCRIPTION
The related issue: https://github.com/open-cluster-management-io/OCM/issues/128

The fmt tool automatically delete some spaces in markdown files, but I also explicitly point out the changes using commits.