### PR TITLE
Add Gatekeeper integration

### DIFF
--- a/content/en/concepts/policy.md
+++ b/content/en/concepts/policy.md
@@ -13,19 +13,17 @@ weight: 5
 
 The policy framework has the following API concepts:
 
-- _Policy Templates_ are the policies that perform a desired check or action. For example,
+- [_Policy Templates_](#managed-cluster-policy-controllers) are the policies that perform a desired check or action. For
+  example,
   [ConfigurationPolicy](/getting-started/integration/policy-controllers#install-the-configuration-policy-controller)
-  objects are embedded in `Policy` objects under the `policy-templates` array. These cannot be
-  deployed to managed clusters on their own.
-- A [`Policy`](#policy) is a grouping mechanism for _Policy Templates_ and is the smallest
-  deployable unit on the hub cluster. Embedded _Policy Templates_ are distributed to applicable
-  managed clusters and acted upon by the appropriate
+  objects are embedded in `Policy` objects under the `policy-templates` array.
+- A [`Policy`](#policy) is a grouping mechanism for _Policy Templates_ and is the smallest deployable unit on the hub
+  cluster. Embedded _Policy Templates_ are distributed to applicable managed clusters and acted upon by the appropriate
   [policy controller](/getting-started/integration/policy-controllers).
-- A [`PolicySet`](#policyset) is a grouping mechanism of `Policy` objects. Compliance of all grouped
-  `Policy` objects is summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its
-  distribution is controlled by a [Placement](/concepts/placement).
-- A [`PlacementBinding`](#placementbinding) binds a [Placement](/concepts/placement) to a `Policy`
-  or `PolicySet`.
+- A [`PolicySet`](#policyset) is a grouping mechanism of `Policy` objects. Compliance of all grouped `Policy` objects is
+  summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its distribution is controlled by a
+  [Placement](/concepts/placement).
+- A [`PlacementBinding`](#placementbinding) binds a [Placement](/concepts/placement) to a `Policy` or `PolicySet`.
 
 The second half of the
 [KubeCon NA 2022 - OCM Multicluster App & Config Management](/kubecon-na-2022-ocm-multicluster-app-and-config-management.pdf)
@@ -33,14 +31,14 @@ also covers an overview of the Policy addon.
 
 ## Policy
 
-A `Policy` is a grouping mechanism for _Policy Templates_ and is the smallest deployable unit on the
-hub cluster. Embedded _Policy Templates_ are distributed to applicable managed clusters and acted
-upon by the appropriate [policy controller](/getting-started/integration/policy-controllers). The
-compliance state and status of a `Policy` represents all embedded _Policy Templates_ in the
-`Policy`. The distribution of `Policy` objects is controlled by a [Placement](/concepts/placement).
+A `Policy` is a grouping mechanism for _Policy Templates_ and is the smallest deployable unit on the hub cluster.
+Embedded _Policy Templates_ are distributed to applicable managed clusters and acted upon by the appropriate
+[policy controller](/getting-started/integration/policy-controllers). The compliance state and status of a `Policy`
+represents all embedded _Policy Templates_ in the `Policy`. The distribution of `Policy` objects is controlled by a
+[Placement](/concepts/placement).
 
-View a simple example of a `Policy` that embeds a `ConfigurationPolicy` policy template to manage a
-namespace called "prod".
+View a simple example of a `Policy` that embeds a `ConfigurationPolicy` policy template to manage a namespace called
+"prod".
 
 ```yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -65,7 +63,7 @@ spec:
           remediationAction: inform
           severity: low
           object-templates:
-            - complianceType: MustHave
+            - complianceType: musthave
               objectDefinition:
                 kind: Namespace # must have namespace 'prod'
                 apiVersion: v1
@@ -73,31 +71,31 @@ spec:
                   name: prod
 ```
 
-At first, you may notice the `annotations`. These are standard annotations that are for
-informational purposes and can be used by user interfaces, custom report scripts, or components that
-integrate with OCM.
+The `annotations` are standard annotations for informational purposes and can be used by user interfaces, custom report
+scripts, or components that integrate with OCM.
 
-Next, you may notice the optional `spec.remediationAction` field. This dictates if the policy
-controller should `inform` or `enforce` when violations are found and overrides the
-`remediationAction` field on each policy template. When set to `inform`, the `Policy` will become
-noncompliant if the underlying policy templates detect that the desired state is not met. When set
+The optional `spec.remediationAction` field dictates whether the policy controller should `inform` or `enforce` when
+violations are found and overrides the `remediationAction` field on each policy template. When set to `inform`, the
+`Policy` will become noncompliant if the underlying policy templates detect that the desired state is not met. When set
 to `enforce`, the policy controller applies the desired state when necessary and feasible.
 
-The `policy-templates` array contains a single `ConfigurationPolicy` called
-`policy-namespace-example`. This `ConfigurationPolicy` has the `remediationAction` set to `inform`
-but it is overridden by the optional global `spec.remediationAction`. The `severity` is for
-informational purposes similar to the `annotations`.
+The `policy-templates` array contains an array of [_Policy Templates_](#managed-cluster-policy-controllers). Here a
+single `ConfigurationPolicy` called `policy-namespace-example` defines a `Namespace` manifest to compare with objects on
+the cluster. It has the `remediationAction` set to `inform` but it is overridden by the optional global
+`spec.remediationAction`. The `severity` is for informational purposes similar to the `annotations`.
 
-The most interesting part is the `object-templates` section under the embedded
-`ConfigurationPolicy`. This describes the `prod` `Namespace` object that the `Policy` applies to.
-The action that the `ConfigurationPolicy` will take is determined by the `complianceType`. In this
-case, it is set to `MustHave` which means the `prod` `Namespace` object will be created if it
-doesn't exist. Other compliance types include `MustNotHave` and `MustOnlyHave`. `MustNotHave` would
-delete the `prod` `Namespace` object. `MustOnlyHave` would ensure the `prod` `Namespace` object only
-exists with the fields defined in the `ConfigurationPolicy`.
+Inside of the embedded `ConfigurationPolicy`, the `object-templates` section describes the `prod` `Namespace` object
+that the `ConfigurationPolicy` applies to. The action that the `ConfigurationPolicy` will take is determined by the
+`complianceType`. In this case, it is set to `musthave` which means the `prod` `Namespace` object will be created if it
+doesn't exist. Other compliance types include `mustnothave` and `mustonlyhave`. `mustnothave` would delete the `prod`
+`Namespace` object. `mustonlyhave` would ensure the `prod` `Namespace` object only exists with the fields defined in the
+`ConfigurationPolicy`. See the
+[`ConfigurationPolicy` page](/getting-started/integration/policy-controllers/configuration-policy) for more information
+or see the [templating in configuration policies](#templating-in-configuration-policies) topic for advanced templating
+use cases with `ConfigurationPolicy`.
 
-When the `Policy` is bound to a [`Placement`](/concepts/placement), the `Policy` status will report
-on each cluster that matched the bound `Placement`:
+When the `Policy` is bound to a [`Placement`](/concepts/placement) using a [`PlacementBinding`](#placementbinding), the
+`Policy` status will report on each cluster that matches the bound `Placement`:
 
 ```yaml
 status:
@@ -125,11 +123,10 @@ kubectl get crd configurationpolicies.policy.open-cluster-management.io -o yaml
 
 ## PlacementBinding
 
-A `PlacementBinding` binds a [Placement](/concepts/placement) to a [`Policy`](#policy) or
-[`PolicySet`](#policyset).
+A `PlacementBinding` binds a [Placement](/concepts/placement) to a [`Policy`](#policy) or [`PolicySet`](#policyset).
 
-Below is an example of a `PlacementBinding` that binds the `policy-namespace` `Policy` to the
-`placement-hub-cluster` `Placement`.
+Below is an example of a `PlacementBinding` that binds the `policy-namespace` `Policy` to the `placement-hub-cluster`
+`Placement`.
 
 ```yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -147,19 +144,17 @@ subjects:
     name: policy-namespace
 ```
 
-Once the `Policy` is bound, it will be distributed to and acted upon by the managed clusters that
-match the `Placement`.
+Once the `Policy` is bound, it will be distributed to and acted upon by the managed clusters that match the `Placement`.
 
 ## PolicySet
 
-A `PolicySet` is a grouping mechanism of [`Policy`](#policy) objects. Compliance of all grouped
-`Policy` objects is summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its
-distribution is controlled by a [Placement](/concepts/placement) when bound through a
-[`PlacementBinding`](#placementbinding).
+A `PolicySet` is a grouping mechanism of [`Policy`](#policy) objects. Compliance of all grouped `Policy` objects is
+summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its distribution is controlled by a
+[Placement](/concepts/placement) when bound through a [`PlacementBinding`](#placementbinding).
 
-This enables a workflow where subject matter experts write `Policy` objects and then an IT
-administrator creates a `PolicySet` that groups the previously written `Policy` objects and binds
-the `PolicySet` to a `Placement` that deploys the `PolicySet`.
+This enables a workflow where subject matter experts write `Policy` objects and then an IT administrator creates a
+`PolicySet` that groups the previously written `Policy` objects and binds the `PolicySet` to a `Placement` that deploys
+the `PolicySet`.
 
 An example of a `PolicySet` is shown below.
 
@@ -170,91 +165,104 @@ metadata:
   name: acm-hardening
   namespace: policies
 spec:
-  description:
-    Apply standard best practices for hardening your Open Cluster Management installation.
+  description: Apply standard best practices for hardening your Open Cluster Management installation.
   policies:
     - policy-check-backups
     - policy-managedclusteraddon-available
     - policy-subscriptions
 ```
 
-## Policy Templates
+## Managed cluster policy controllers
 
-Configuration policies support the inclusion of Golang text templates in the object definitions.
-These templates are resolved at runtime either on the hub cluster or the target managed cluster
-using configurations related to that cluster. This gives you the ability to define configuration
-policies with dynamic content and to inform or enforce Kubernetes resources that are customized to
-the target cluster.
+The [`Policy`](#policy) on the hub delivers the policies defined in `spec.policy-templates` to the managed clusters via
+the policy framework controllers. Once on the managed cluster, these _Policy Templates_ are acted upon by the associated
+controller on the managed cluster. The policy framework supports delivering the _Policy Template_ kinds listed here:
 
-The template syntax must follow the Golang template language specification, and the resource
-definition generated from the resolved template must be a valid YAML. (See the
-[Golang documentation about package templates](https://golang.org/pkg/text/template/) for more
-information.) Any errors in template validation appear as policy violations. When you use a custom
-template function, the values are replaced at runtime.
+- Configuration policy
 
-Template functions, such as resource-specific and generic `lookup` template functions, are available
-for referencing Kubernetes resources on the hub cluster (using the `{{hub ... hub}}` delimiters), or
-managed cluster (using the `{{ ... }}` delimiters). See the
-[Hub cluster templates section](#hub-cluster-templates) for more details. The resource-specific
-functions are used for convenience and makes content of the resources more accessible. If you use
-the generic function, `lookup`, which is more advanced, it is best to be familiar with the YAML
-structure of the resource that is being looked up. In addition to these functions, utility functions
-like `base64encode`, `base64decode`, `indent`, `autoindent`, `toInt`, and `toBool` are also
-available.
+  The `ConfigurationPolicy` is provided by OCM and defines Kubernetes manifests to compare with objects that currently
+  exist on the cluster. The action that the `ConfigurationPolicy` will take is determined by its `complianceType`.
+  Compliance types include `musthave`, `mustnothave`, and `mustonlyhave`. `musthave` means the object should have the
+  listed keys and values as a subset of the larger object. `mustnothave` means an object matching the listed keys and
+  values should not exist. `mustonlyhave` ensures objects only exist with the keys and values exactly as defined. See
+  the page on [Configuration Policy](/getting-started/integration/policy-controllers/configuration-policy) for more
+  information.
 
-To conform templates with YAML syntax, templates must be set in the policy resource as strings using
-quotes or a block character (`|` or `>`). This causes the resolved template value to also be a
-string. To override this, consider using `toInt` or `toBool` as the final function in the template
-to initiate further processing that forces the value to be interpreted as an integer or boolean
-respectively.
+- Open Policy Agent Gatekeeper
+
+  Gatekeeper is a validating webhook with auditing capabilities that can enforce custom resource definition-based
+  policies that are run with the Open Policy Agent (OPA). Gatekeeper `ConstraintTemplates` and constraints can be
+  provided in an OCM `Policy` to sync to managed clusters that have Gatekeeper installed on them. See the page on
+  [Gatekeeper integration](/getting-started/integration/policy-controllers/gatekeeper) for more information.
+
+## Templating in configuration policies
+
+Configuration policies support the inclusion of Golang text templates in the object definitions. These templates are
+resolved at runtime either on the hub cluster or the target managed cluster using configurations related to that
+cluster. This gives you the ability to define configuration policies with dynamic content and to inform or enforce
+Kubernetes resources that are customized to the target cluster.
+
+The template syntax must follow the Golang template language specification, and the resource definition generated from
+the resolved template must be a valid YAML. (See the
+[Golang documentation about package templates](https://golang.org/pkg/text/template/) for more information.) Any errors
+in template validation appear as policy violations. When you use a custom template function, the values are replaced at
+runtime.
+
+Template functions, such as resource-specific and generic `lookup` template functions, are available for referencing
+Kubernetes resources on the hub cluster (using the `{{hub ... hub}}` delimiters), or managed cluster (using the
+`{{ ... }}` delimiters). See the [Hub cluster templates section](#hub-cluster-templates) for more details. The
+resource-specific functions are used for convenience and makes content of the resources more accessible. If you use the
+generic function, `lookup`, which is more advanced, it is best to be familiar with the YAML structure of the resource
+that is being looked up. In addition to these functions, utility functions like `base64encode`, `base64decode`,
+`indent`, `autoindent`, `toInt`, and `toBool` are also available.
+
+To conform templates with YAML syntax, templates must be set in the policy resource as strings using quotes or a block
+character (`|` or `>`). This causes the resolved template value to also be a string. To override this, consider using
+`toInt` or `toBool` as the final function in the template to initiate further processing that forces the value to be
+interpreted as an integer or boolean respectively.
 
 To bypass template processing you can either:
 
-- Override a single template by wrapping the template in additional braces. For example, the
-  template `{{ template content }}` would become `{{ '{{ template content }}' }}`.
+- Override a single template by wrapping the template in additional braces. For example, the template
+  `{{ template content }}` would become `{{ '{{ template content }}' }}`.
 - Override all templates in a `ConfigurationPolicy` by adding the
-  `policy.open-cluster-management.io/disable-templates: "true"` annotation in the
-  `ConfigurationPolicy` section of your `Policy`. Template processing will be bypassed for that
-  `ConfigurationPolicy`.
+  `policy.open-cluster-management.io/disable-templates: "true"` annotation in the `ConfigurationPolicy` section of your
+  `Policy`. Template processing will be bypassed for that `ConfigurationPolicy`.
 
-### Hub cluster templates
+### Hub cluster templating in configuration policies
 
-Hub cluster templates are used to define configuration policies that are dynamically customized to
-the target cluster. This reduces the need to create separate policies for each target cluster or
-hardcode configuration values in the policy definitions.
+Hub cluster templates are used to define configuration policies that are dynamically customized to the target cluster.
+This reduces the need to create separate policies for each target cluster or hardcode configuration values in the policy
+definitions.
 
-Hub cluster templates are based on Golang text template specifications, and the `{{hub … hub}}`
-delimiter indicates a hub cluster template in a configuration policy.
+Hub cluster templates are based on Golang text template specifications, and the `{{hub … hub}}` delimiter indicates a
+hub cluster template in a configuration policy.
 
-A configuration policy definition can contain both hub cluster and managed cluster templates. Hub
-cluster templates are processed first on the hub cluster, then the policy definition with resolved
-hub cluster templates is propagated to the target clusters. On the managed cluster, the
-Configuration Policy controller processes any managed cluster templates in the policy definition and
-then enforces or verifies the fully resolved object definition.
+A configuration policy definition can contain both hub cluster and managed cluster templates. Hub cluster templates are
+processed first on the hub cluster, then the policy definition with resolved hub cluster templates is propagated to the
+target clusters. On the managed cluster, the Configuration Policy controller processes any managed cluster templates in
+the policy definition and then enforces or verifies the fully resolved object definition.
 
-In OCM versions 0.9.x and older, policies are processed on the hub cluster only upon creation or
-after an update. Therefore, hub cluster templates are only resolved to the data in the referenced
-resources upon policy creation or update. Any changes to the referenced resources are not
-automatically synced to the policies.
+In OCM versions 0.9.x and older, policies are processed on the hub cluster only upon creation or after an update.
+Therefore, hub cluster templates are only resolved to the data in the referenced resources upon policy creation or
+update. Any changes to the referenced resources are not automatically synced to the policies.
 
-A special annotation, `policy.open-cluster-management.io/trigger-update` can be used to indicate
-changes to the data referenced by the templates. Any change to the special annotation value
-initiates template processing, and the latest contents of the referenced resource are read and
-updated in the policy definition that is the propagator for processing on managed clusters. A
-typical way to use this annotation is to increment the value by one each time.
+A special annotation, `policy.open-cluster-management.io/trigger-update` can be used to indicate changes to the data
+referenced by the templates. Any change to the special annotation value initiates template processing, and the latest
+contents of the referenced resource are read and updated in the policy definition that is the propagator for processing
+on managed clusters. A typical way to use this annotation is to increment the value by one each time.
 
-### Template encryption details
+### Templating value encryption
 
-The encryption algorithm uses AES-CBC with 256-bit keys. Each encryption key is unique per managed
-cluster and is automatically rotated every 30 days. This ensures that your decrypted value is never
-stored in the policy on the managed cluster.
+The encryption algorithm uses AES-CBC with 256-bit keys. Each encryption key is unique per managed cluster and is
+automatically rotated every 30 days. This ensures that your decrypted value is never stored in the policy on the managed
+cluster.
 
-To force an immediate encryption key rotation, delete the
-`policy.open-cluster-management.io/last-rotated` annotation on the `policy-encryption-key` Secret in
-the managed cluster namespace on the hub cluster. Policies are then reprocessed to use the new
-encryption key.
+To force an immediate encryption key rotation, delete the `policy.open-cluster-management.io/last-rotated` annotation on
+the `policy-encryption-key` Secret in the managed cluster namespace on the hub cluster. Policies are then reprocessed to
+use the new encryption key.
 
-### Template functions
+### Templating functions
 
 | Function           | Description                                                                                                                                                                                                         | Sample                                                                                                                                       |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -270,8 +278,7 @@ encryption key.
 | `toBool`           | Returns the boolean value of the input string and ensures that the value is interpreted as a boolean in the YAML.                                                                                                   | `enabled: \|`<br />`{{ (fromConfigMap "site-config" "site1" "enabled") \| toBool }}`                                                         |
 | `protect`          | Encrypts the input string. It is decrypted when the policy is evaluated. On the replicated policy in the managed cluster namespace, the resulting value resembles the following: `$ocm_encrypted:<encrypted-value>` | `enabled: \|`<br />`{{hub "(lookup "route.openshift.io/v1" "Route" "openshift-authentication" "oauth-openshift").spec.host \| protect hub}}` |
 
-Additionally, OCM supports the following template functions that are included from the `sprig` open
-source project:
+Additionally, OCM supports the following template functions that are included from the `sprig` open source project:
 
 - `cat`
 - `contains`

--- a/content/en/getting-started/integration/policy-controllers/_index.md
+++ b/content/en/getting-started/integration/policy-controllers/_index.md
@@ -1,0 +1,29 @@
+---
+title: Policy controllers
+weight: 10
+---
+
+The [Policy API](/concepts/policy) on the hub delivers the policies defined in `spec.policy-templates` to the managed
+clusters via the [policy framework controllers](/getting-started/integration/policy-framework). Once on the managed
+cluster, these _Policy Templates_ are acted upon by the associated controller on the managed cluster. The policy
+framework supports delivering the _Policy Template_ kinds listed.
+
+<!-- spellchecker-disable -->
+
+{{< toc >}}
+
+<!-- spellchecker-enable -->
+
+## [Configuration policy](/getting-started/integration/policy-controllers/configuration-policy)
+
+  The `ConfigurationPolicy` is provided by OCM and defines Kubernetes manifests to compare with objects that currently
+  exist on the cluster. The action that the `ConfigurationPolicy` will take is determined by its `complianceType`.
+  Compliance types include `musthave`, `mustnothave`, and `mustonlyhave`. `musthave` means the object should have the
+  listed keys and values as a subset of the larger object. `mustnothave` means an object matching the listed keys and
+  values should not exist. `mustonlyhave` ensures objects only exist with the keys and values exactly as defined.
+
+## [Open Policy Agent Gatekeeper](/getting-started/integration/policy-controllers/gatekeeper)
+
+  Gatekeeper is a validating webhook with auditing capabilities that can enforce custom resource definition-based
+  policies that are run with the Open Policy Agent (OPA). Gatekeeper `ConstraintTemplates` and constraints can be
+  provided in an OCM `Policy` to sync to managed clusters that have Gatekeeper installed on them.

--- a/content/en/getting-started/integration/policy-controllers/configuration-policy.md
+++ b/content/en/getting-started/integration/policy-controllers/configuration-policy.md
@@ -1,9 +1,10 @@
 ---
-title: Policy controllers
-weight: 11
+title: Configuration Policy
+weight: 15
 ---
 
-After policy framework is installed, you can install the policy controllers to the managed clusters.
+The `ConfigurationPolicy` defines Kubernetes manifests to compare with objects that currently exist on the cluster. The
+Configuration policy controller is provided by Open Cluster Management and runs on managed clusters.
 
 <!-- spellchecker-disable -->
 
@@ -11,30 +12,27 @@ After policy framework is installed, you can install the policy controllers to t
 
 <!-- spellchecker-enable -->
 
-## Prerequisite
+## Prerequisites
 
-You must meet the following prerequisites to install the policy controllers:
+You must meet the following prerequisites to install the configuration policy controller:
 
 - Ensure [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) and
   [`kustomize`](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
 
-- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from
-  the source.
+- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
 
 - Ensure the `open-cluster-management` _policy framework_ is installed. See
   [Policy Framework](/getting-started/integration/policy-framework) for more information.
 
-## Install the configuration policy controller to the managed cluster(s)
+## Installing the configuration policy controller
 
 ### Deploy via Clusteradm CLI
 
 Ensure `clusteradm` CLI is installed and is newer than v0.3.0. Download and extract the
-[clusteradm binary](https://github.com/open-cluster-management-io/clusteradm/releases/latest). For
-more details see the
+[clusteradm binary](https://github.com/open-cluster-management-io/clusteradm/releases/latest). For more details see the
 [clusteradm GitHub page](https://github.com/open-cluster-management-io/clusteradm/blob/main/README.md#quick-start).
 
-1. Deploy the configuration policy controller to the managed cluster(s) (this command is the same
-   for a self-managed hub):
+1. Deploy the configuration policy controller to the managed clusters (this command is the same for a self-managed hub):
 
    ```Shell
    # Deploy the configuration policy controller
@@ -68,7 +66,7 @@ more details see the
 
    # Apply the CRD
    export COMPONENT="config-policy-controller"
-   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/${COMPONENT}/v0.9.0/deploy"
+   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/${COMPONENT}/v0.11.0/deploy"
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_configurationpolicies.yaml
 
    # Set the managed cluster name
@@ -79,9 +77,8 @@ more details see the
    kubectl set env deployment/${COMPONENT} -n ${MANAGED_NAMESPACE} --containers=${COMPONENT} WATCH_NAMESPACE=${MANAGED_CLUSTER_NAME}
    ```
 
-   - See
-     [config-policy-controller](https://github.com/open-cluster-management-io/config-policy-controller)
-     for more information.
+   - See [config-policy-controller](https://github.com/open-cluster-management-io/config-policy-controller) for more
+     information.
 
 2. Ensure the pod is running on the managed cluster with the following command:
 
@@ -91,13 +88,12 @@ more details see the
    config-policy-controller-7f8fb64d8c-pmfx4          1/1     Running   0          44s
    ```
 
-## What is next
+## Sample configuration policy
 
-After a successful deployment, test the policy framework and configuration policy controller with a
-sample policy. You can use a policy that includes a `Placement` mapping or if you installed
-Application management's `PlacementRule` support you can use either placement implementation.
-Perform the steps in the **Placement API** or the **Placement Rule API** section based on which
-placement API you desire to use.
+After a successful deployment, test the policy framework and configuration policy controller with a sample policy. You
+can use a policy that includes a `Placement` mapping or if you installed Application management's `PlacementRule`
+support you can use either placement implementation. Perform the steps in the **Placement API** or the **Placement Rule
+API** section based on which placement API you desire to use.
 
 For more information on how to use a `ConfigurationPolicy`, read the
 [`Policy` API concept section](/getting-started/integration/policy-framework#policy).
@@ -114,17 +110,17 @@ For more information on how to use a `ConfigurationPolicy`, read the
    kubectl apply -n default -f https://raw.githubusercontent.com/stolostron/policy-collection/main/community/CM-Configuration-Management/policy-pod-placement.yaml
    ```
 
-2. Update the `Placement` to distribute the policy to the managed cluster with the following command
-   (this `clusterSelector` will deploy the policy to all managed clusters):
+2. Update the `Placement` to distribute the policy to the managed cluster with the following command (this
+   `clusterSelector` will deploy the policy to all managed clusters):
 
    ```Shell
    kubectl patch -n default placement.cluster.open-cluster-management.io/placement-policy-pod --type=merge -p "{\"spec\":{\"predicates\":[{\"requiredClusterSelector\":{\"labelSelector\":{\"matchExpressions\":[]}}}]}}"
    ```
 
-3. Make sure the `default` namespace has a `ManagedClusterSetBinding` for a `ManagedClusterSet` with
-   at least one managed cluster resource in the `ManagedClusterSet`. See
-   [Bind ManagedClusterSet to a namespace](/concepts/managedclusterset#bind-managedclusterset-to-a-namespace)
-   for more information on this.
+3. Make sure the `default` namespace has a `ManagedClusterSetBinding` for a `ManagedClusterSet` with at least one
+   managed cluster resource in the `ManagedClusterSet`. See
+   [Bind ManagedClusterSet to a namespace](/concepts/managedclusterset#bind-managedclusterset-to-a-namespace) for more
+   information on this.
 
 4. To confirm that the managed cluster is selected by the `Placement`, run the following command:
 
@@ -152,16 +148,15 @@ For more information on how to use a `ConfigurationPolicy`, read the
    kubectl apply -n default -f https://raw.githubusercontent.com/open-cluster-management/policy-collection/main/stable/CM-Configuration-Management/policy-pod.yaml
    ```
 
-2. Update the `PlacementRule` to distribute the policy to the managed cluster with the following
-   command (this `clusterSelector` will deploy the policy to all managed clusters):
+2. Update the `PlacementRule` to distribute the policy to the managed cluster with the following command (this
+   `clusterSelector` will deploy the policy to all managed clusters):
 
    ```Shell
    $ kubectl patch -n default placementrule.apps.open-cluster-management.io/placement-policy-pod --type=merge -p "{\"spec\":{\"clusterSelector\":{\"matchExpressions\":[]}}}"
    placementrule.apps.open-cluster-management.io/placement-policy-pod patched
    ```
 
-3. To confirm that the managed cluster is selected by the `PlacementRule`, run the following
-   command:
+3. To confirm that the managed cluster is selected by the `PlacementRule`, run the following command:
 
    ```Shell
    $ kubectl get -n default placementrule.apps.open-cluster-management.io/placement-policy-pod -o yaml
@@ -175,19 +170,18 @@ For more information on how to use a `ConfigurationPolicy`, read the
 
 ### Final steps to apply the policy
 
-Perform the following steps to continue working with the policy to test the policy framework now
-that a placement method has been selected between `Placement` or `PlacementRule`.
+Perform the following steps to continue working with the policy to test the policy framework now that a placement method
+has been selected between `Placement` or `PlacementRule`.
 
-1. Enforce the policy to make the configuration policy automatically correct any misconfigurations
-   on the managed cluster:
+1. Enforce the policy to make the configuration policy automatically correct any misconfigurations on the managed
+   cluster:
 
    ```Shell
    $ kubectl patch -n default policy.policy.open-cluster-management.io/policy-pod --type=merge -p "{\"spec\":{\"remediationAction\": \"enforce\"}}"
    policy.policy.open-cluster-management.io/policy-pod patched
    ```
 
-2. After a few seconds, your policy is propagated to the managed cluster. To confirm, run the
-   following command:
+2. After a few seconds, your policy is propagated to the managed cluster. To confirm, run the following command:
 
    ```Shell
    $ kubectl config use-context ${CTX_MANAGED_CLUSTER}
@@ -196,8 +190,8 @@ that a placement method has been selected between `Placement` or `PlacementRule`
    cluster1    default.policy-pod   enforce              Compliant          4m32s
    ```
 
-3. The missing pod is created by the policy on the managed cluster. To confirm, run the following
-   command on the managed cluster:
+3. The missing pod is created by the policy on the managed cluster. To confirm, run the following command on the managed
+   cluster:
 
    ```Shell
    $ kubectl get pod -n default

--- a/content/en/getting-started/integration/policy-controllers/gatekeeper.md
+++ b/content/en/getting-started/integration/policy-controllers/gatekeeper.md
@@ -1,0 +1,135 @@
+---
+title: Open Policy Agent Gatekeeper
+weight: 15
+---
+
+[Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/) is a validating webhook with auditing capabilities
+that can enforce custom resource definition-based policies that are run with the Open Policy Agent (OPA). Gatekeeper
+constraints can be used to evaluate Kubernetes resource compliance. You can leverage OPA as the policy engine, and use
+Rego as the policy language.
+
+<!-- spellchecker-disable -->
+
+{{< toc >}}
+
+<!-- spellchecker-enable -->
+
+## Installing Gatekeeper
+
+See the [Gatekeeper documentation](https://open-policy-agent.github.io/gatekeeper/website/docs/install) to install the
+desired version of Gatekeeper to the managed cluster.
+
+## Sample Gatekeeper policy
+
+Gatekeeper policies are written using constraint templates and constraints. View the following YAML examples that use
+Gatekeeper constraints in an OCM `Policy`:
+
+- `ConstraintTemplates` and constraints: Use the Gatekeeper integration feature by using OCM policies for multicluster
+  distribution of Gatekeeper constraints and Gatekeeper audit results aggregation on the hub cluster. The following
+  example defines a Gatekeeper `ConstraintTemplate` and constraint (`K8sRequiredLabels`) to ensure the "gatekeeper"
+  label is set on all namespaces:
+
+  ```yaml
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  metadata:
+    name: require-gatekeeper-labels-on-ns
+  spec:
+    remediationAction: inform # (1)
+    disabled: false
+    policy-templates:
+      - objectDefinition:
+          apiVersion: templates.gatekeeper.sh/v1beta1
+          kind: ConstraintTemplate
+          metadata:
+            name: k8srequiredlabels
+          spec:
+            crd:
+              spec:
+                names:
+                  kind: K8sRequiredLabels
+                validation:
+                  openAPIV3Schema:
+                    properties:
+                      labels:
+                        type: array
+                        items: string
+            targets:
+              - target: admission.k8s.gatekeeper.sh
+                rego: |
+                  package k8srequiredlabels
+                  violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                    provided := {label | input.review.object.metadata.labels[label]}
+                    required := {label | label := input.parameters.labels[_]}
+                    missing := required - provided
+                    count(missing) > 0
+                    msg := sprintf("you must provide labels: %v", [missing])
+                  }
+      - objectDefinition:
+          apiVersion: constraints.gatekeeper.sh/v1beta1
+          kind: K8sRequiredLabels
+          metadata:
+            name: ns-must-have-gk
+          spec:
+            enforcementAction: dryrun
+            match:
+              kinds:
+                - apiGroups: [""]
+                  kinds: ["Namespace"]
+            parameters:
+              labels: ["gatekeeper"]
+  ```
+
+  1. Since the remediationAction is set to "inform", the `enforcementAction` field of the Gatekeeper constraint is
+     overridden to "warn". This means that Gatekeeper detects and warns you about creating or updating a namespace that
+     is missing the "gatekeeper" label. If the policy `remediationAction` is set to "enforce", the Gatekeeper constraint
+     `enforcementAction` field is overridden to "deny". In this context, this configuration prevents any user from
+     creating or updating a namespace that is missing the gatekeeper label.
+
+  With the previous policy, you might receive the following policy status message:
+
+  > warn - you must provide labels: {"gatekeeper"} (on Namespace default); warn - you must provide labels:
+  > {"gatekeeper"} (on Namespace gatekeeper-system).
+
+  Once a policy containing Gatekeeper constraints or `ConstraintTemplates` is deleted, the constraints and
+  `ConstraintTemplates` are also deleted from the managed cluster.
+
+  **Notes:**
+
+  - The Gatekeeper audit functionality runs every minute by default. Audit results are sent back to the hub cluster to
+    be viewed in the OCM policy status of the managed cluster.
+
+- Auditing Gatekeeper events: The following example uses an OCM
+  [configuration policy](getting-started/integration/configuration-policy) within an OCM policy to check for Kubernetes
+  API requests denied by the Gatekeeper admission webhook:
+
+  ```yaml
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  metadata:
+    name: policy-gatekeeper-admission
+  spec:
+    remediationAction: inform
+    disabled: false
+    policy-templates:
+      - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-admission
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: low
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: v1
+                kind: Event
+                metadata:
+                  namespace: gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
+                  annotations:
+                    constraint_action: deny
+                    constraint_kind: K8sRequiredLabels
+                    constraint_name: ns-must-have-gk
+                    event_type: violation
+  ```

--- a/content/en/getting-started/integration/policy-framework.md
+++ b/content/en/getting-started/integration/policy-framework.md
@@ -3,9 +3,8 @@ title: Policy framework
 weight: 10
 ---
 
-The policy framework provides governance capabilities to OCM managed Kubernetes clusters. Policies
-provide visibility and drive remediation for various security and configuration aspects to help IT
-administrators meet their requirements.
+The policy framework provides governance capabilities to OCM managed Kubernetes clusters. Policies provide visibility
+and drive remediation for various security and configuration aspects to help IT administrators meet their requirements.
 
 <!-- spellchecker-disable -->
 
@@ -15,8 +14,8 @@ administrators meet their requirements.
 
 ## API Concepts
 
-View the [Policy API](/concepts/policy) page for additional details about the Policy API managed by
-the Policy Framework components, including:
+View the [Policy API](/concepts/policy) page for additional details about the Policy API managed by the Policy Framework
+components, including:
 
 - [`Policy`](/concepts/policy#policy)
 - [`PolicySet`](/concepts/policy#policyset)
@@ -28,8 +27,8 @@ the Policy Framework components, including:
    <img src="/policy-framework-architecture-diagram.jpg" alt="Policy framework architecture" style="margin: 0 auto; width: 80%">
 </div>
 
-The governance policy framework distributes policies to managed clusters and collects results to
-send back to the hub cluster.
+The governance policy framework distributes policies to managed clusters and collects results to send back to the hub
+cluster.
 
 - [Policy propagator](https://github.com/open-cluster-management-io/governance-policy-propagator)
 - [Policy framework addon](https://github.com/open-cluster-management-io/governance-policy-framework-addon)
@@ -48,8 +47,7 @@ You must meet the following prerequisites to install the policy framework:
 - Ensure [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) and
   [`kustomize`](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
 
-- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from
-  the source.
+- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
 
 - Ensure the `open-cluster-management` _cluster manager_ is installed. See
   [Start the control plane](/getting-started/installation/start-the-control-plane) for more information.
@@ -57,11 +55,10 @@ You must meet the following prerequisites to install the policy framework:
 - Ensure the `open-cluster-management` _klusterlet_ is installed. See
   [Register a cluster](/getting-started/installation/register-a-cluster) for more information.
 
-- If you are using `PlacementRules` with your policies, ensure the `open-cluster-management`
-  _application_ is installed . See
-  [Application management](/getting-started/integration/app-lifecycle) for more information. If you
-  are using the default `Placement` API, you can skip the Application management installation, but
-  you do need to install the `PlacementRule` CRD with this command:
+- If you are using `PlacementRules` with your policies, ensure the `open-cluster-management` _application_ is installed
+  . See [Application management](/getting-started/integration/app-lifecycle) for more information. If you are using the
+  default `Placement` API, you can skip the Application management installation, but you do need to install the
+  `PlacementRule` CRD with this command:
 
   ```Shell
   kubectl apply -f https://raw.githubusercontent.com/open-cluster-management-io/multicloud-operators-subscription/main/deploy/hub-common/apps.open-cluster-management.io_placementrules_crd.yaml
@@ -72,8 +69,7 @@ You must meet the following prerequisites to install the policy framework:
 ### Install via Clusteradm CLI
 
 Ensure `clusteradm` CLI is installed and is at least v0.3.0. Download and extract the
-[clusteradm binary](https://github.com/open-cluster-management-io/clusteradm/releases/latest). For
-more details see the
+[clusteradm binary](https://github.com/open-cluster-management-io/clusteradm/releases/latest). For more details see the
 [clusteradm GitHub page](https://github.com/open-cluster-management-io/clusteradm/blob/main/README.md#quick-start).
 
 1. Deploy the policy framework controllers to the hub cluster:
@@ -106,8 +102,8 @@ more details see the
 
 ### Install from source
 
-1. Deploy the policy Custom Resource Definitions (CRD) and policy propagator component to the
-   `open-cluster-management` namespace on the hub cluster with the following commands:
+1. Deploy the policy Custom Resource Definitions (CRD) and policy propagator component to the `open-cluster-management`
+   namespace on the hub cluster with the following commands:
 
    ```Shell
    # Configure kubectl to point to the hub cluster
@@ -124,7 +120,7 @@ more details see the
    export HUB_KUBECONFIG="hub-kubeconfig"
 
    # Apply the CRDs
-   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.9.0/deploy"
+   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.11.0/deploy"
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policies.yaml
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_placementbindings.yaml
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policyautomations.yaml
@@ -172,8 +168,8 @@ more details see the
    governance-policy-framework-addon-57579b7c-652zj         1/1     Running   0          87s
    ```
 
-   **NOTE**: If you are using clusteradm v0.3.x or older, the pod will be called `governance-policy-framework` and
-   have a container per synchronization component (2 on a self-managed Hub, or 3 on a managed cluster).
+   **NOTE**: If you are using clusteradm v0.3.x or older, the pod will be called `governance-policy-framework` and have
+   a container per synchronization component (2 on a self-managed Hub, or 3 on a managed cluster).
 
 ### Deploy from source
 
@@ -214,7 +210,7 @@ more details see the
 
    # Apply the policy CRD
    export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io"
-   kubectl apply -f ${GIT_PATH}/governance-policy-propagator/v0.9.0/deploy/crds/policy.open-cluster-management.io_policies.yaml
+   kubectl apply -f ${GIT_PATH}/governance-policy-propagator/v0.11.0/deploy/crds/policy.open-cluster-management.io_policies.yaml
 
    # Set the managed cluster name and create the namespace
    export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
@@ -222,7 +218,7 @@ more details see the
 
    # Deploy the synchronization component
    export COMPONENT="governance-policy-framework-addon"
-   kubectl apply -f ${GIT_PATH}/${COMPONENT}/v0.9.0/deploy/operator.yaml -n ${MANAGED_NAMESPACE}
+   kubectl apply -f ${GIT_PATH}/${COMPONENT}/v0.11.0/deploy/operator.yaml -n ${MANAGED_NAMESPACE}
    kubectl patch deployment governance-policy-framework-addon -n ${MANAGED_NAMESPACE} \
      -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"governance-policy-framework-addon\",\"args\":[\"--hub-cluster-configfile=/var/run/klusterlet/kubeconfig\", \"--cluster-namespace=${MANAGED_CLUSTER_NAME}\", \"--enable-lease=true\", \"--log-level=2\", \"--disable-spec-sync=${DEPLOY_ON_HUB}\"]}]}}}}"
    ```

--- a/content/zh/concepts/policy.md
+++ b/content/zh/concepts/policy.md
@@ -65,7 +65,7 @@ spec:
           remediationAction: inform
           severity: low
           object-templates:
-            - complianceType: MustHave
+            - complianceType: musthave
               objectDefinition:
                 kind: Namespace # must have namespace 'prod'
                 apiVersion: v1
@@ -91,9 +91,9 @@ informational purposes similar to the `annotations`.
 The most interesting part is the `object-templates` section under the embedded
 `ConfigurationPolicy`. This describes the `prod` `Namespace` object that the `Policy` applies to.
 The action that the `ConfigurationPolicy` will take is determined by the `complianceType`. In this
-case, it is set to `MustHave` which means the `prod` `Namespace` object will be created if it
-doesn't exist. Other compliance types include `MustNotHave` and `MustOnlyHave`. `MustNotHave` would
-delete the `prod` `Namespace` object. `MustOnlyHave` would ensure the `prod` `Namespace` object only
+case, it is set to `musthave` which means the `prod` `Namespace` object will be created if it
+doesn't exist. Other compliance types include `mustnothave` and `mustonlyhave`. `mustnothave` would
+delete the `prod` `Namespace` object. `mustonlyhave` would ensure the `prod` `Namespace` object only
 exists with the fields defined in the `ConfigurationPolicy`.
 
 When the `Policy` is bound to a [`Placement`](/concepts/placement), the `Policy` status will report

--- a/content/zh/concepts/policy.md
+++ b/content/zh/concepts/policy.md
@@ -13,19 +13,17 @@ weight: 5
 
 The policy framework has the following API concepts:
 
-- _Policy Templates_ are the policies that perform a desired check or action. For example,
+- [_Policy Templates_](#managed-cluster-policy-controllers) are the policies that perform a desired check or action. For
+  example,
   [ConfigurationPolicy](/getting-started/integration/policy-controllers#install-the-configuration-policy-controller)
-  objects are embedded in `Policy` objects under the `policy-templates` array. These cannot be
-  deployed to managed clusters on their own.
-- A [`Policy`](#policy) is a grouping mechanism for _Policy Templates_ and is the smallest
-  deployable unit on the hub cluster. Embedded _Policy Templates_ are distributed to applicable
-  managed clusters and acted upon by the appropriate
+  objects are embedded in `Policy` objects under the `policy-templates` array.
+- A [`Policy`](#policy) is a grouping mechanism for _Policy Templates_ and is the smallest deployable unit on the hub
+  cluster. Embedded _Policy Templates_ are distributed to applicable managed clusters and acted upon by the appropriate
   [policy controller](/getting-started/integration/policy-controllers).
-- A [`PolicySet`](#policyset) is a grouping mechanism of `Policy` objects. Compliance of all grouped
-  `Policy` objects is summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its
-  distribution is controlled by a [Placement](/concepts/placement).
-- A [`PlacementBinding`](#placementbinding) binds a [Placement](/concepts/placement) to a `Policy`
-  or `PolicySet`.
+- A [`PolicySet`](#policyset) is a grouping mechanism of `Policy` objects. Compliance of all grouped `Policy` objects is
+  summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its distribution is controlled by a
+  [Placement](/concepts/placement).
+- A [`PlacementBinding`](#placementbinding) binds a [Placement](/concepts/placement) to a `Policy` or `PolicySet`.
 
 The second half of the
 [KubeCon NA 2022 - OCM Multicluster App & Config Management](/kubecon-na-2022-ocm-multicluster-app-and-config-management.pdf)
@@ -33,14 +31,14 @@ also covers an overview of the Policy addon.
 
 ## Policy
 
-A `Policy` is a grouping mechanism for _Policy Templates_ and is the smallest deployable unit on the
-hub cluster. Embedded _Policy Templates_ are distributed to applicable managed clusters and acted
-upon by the appropriate [policy controller](/getting-started/integration/policy-controllers). The
-compliance state and status of a `Policy` represents all embedded _Policy Templates_ in the
-`Policy`. The distribution of `Policy` objects is controlled by a [Placement](/concepts/placement).
+A `Policy` is a grouping mechanism for _Policy Templates_ and is the smallest deployable unit on the hub cluster.
+Embedded _Policy Templates_ are distributed to applicable managed clusters and acted upon by the appropriate
+[policy controller](/getting-started/integration/policy-controllers). The compliance state and status of a `Policy`
+represents all embedded _Policy Templates_ in the `Policy`. The distribution of `Policy` objects is controlled by a
+[Placement](/concepts/placement).
 
-View a simple example of a `Policy` that embeds a `ConfigurationPolicy` policy template to manage a
-namespace called "prod".
+View a simple example of a `Policy` that embeds a `ConfigurationPolicy` policy template to manage a namespace called
+"prod".
 
 ```yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -73,31 +71,31 @@ spec:
                   name: prod
 ```
 
-At first, you may notice the `annotations`. These are standard annotations that are for
-informational purposes and can be used by user interfaces, custom report scripts, or components that
-integrate with OCM.
+The `annotations` are standard annotations for informational purposes and can be used by user interfaces, custom report
+scripts, or components that integrate with OCM.
 
-Next, you may notice the optional `spec.remediationAction` field. This dictates if the policy
-controller should `inform` or `enforce` when violations are found and overrides the
-`remediationAction` field on each policy template. When set to `inform`, the `Policy` will become
-noncompliant if the underlying policy templates detect that the desired state is not met. When set
+The optional `spec.remediationAction` field dictates whether the policy controller should `inform` or `enforce` when
+violations are found and overrides the `remediationAction` field on each policy template. When set to `inform`, the
+`Policy` will become noncompliant if the underlying policy templates detect that the desired state is not met. When set
 to `enforce`, the policy controller applies the desired state when necessary and feasible.
 
-The `policy-templates` array contains a single `ConfigurationPolicy` called
-`policy-namespace-example`. This `ConfigurationPolicy` has the `remediationAction` set to `inform`
-but it is overridden by the optional global `spec.remediationAction`. The `severity` is for
-informational purposes similar to the `annotations`.
+The `policy-templates` array contains an array of [_Policy Templates_](#managed-cluster-policy-controllers). Here a
+single `ConfigurationPolicy` called `policy-namespace-example` defines a `Namespace` manifest to compare with objects on
+the cluster. It has the `remediationAction` set to `inform` but it is overridden by the optional global
+`spec.remediationAction`. The `severity` is for informational purposes similar to the `annotations`.
 
-The most interesting part is the `object-templates` section under the embedded
-`ConfigurationPolicy`. This describes the `prod` `Namespace` object that the `Policy` applies to.
-The action that the `ConfigurationPolicy` will take is determined by the `complianceType`. In this
-case, it is set to `musthave` which means the `prod` `Namespace` object will be created if it
-doesn't exist. Other compliance types include `mustnothave` and `mustonlyhave`. `mustnothave` would
-delete the `prod` `Namespace` object. `mustonlyhave` would ensure the `prod` `Namespace` object only
-exists with the fields defined in the `ConfigurationPolicy`.
+Inside of the embedded `ConfigurationPolicy`, the `object-templates` section describes the `prod` `Namespace` object
+that the `ConfigurationPolicy` applies to. The action that the `ConfigurationPolicy` will take is determined by the
+`complianceType`. In this case, it is set to `musthave` which means the `prod` `Namespace` object will be created if it
+doesn't exist. Other compliance types include `mustnothave` and `mustonlyhave`. `mustnothave` would delete the `prod`
+`Namespace` object. `mustonlyhave` would ensure the `prod` `Namespace` object only exists with the fields defined in the
+`ConfigurationPolicy`. See the
+[`ConfigurationPolicy` page](/getting-started/integration/policy-controllers/configuration-policy) for more information
+or see the [templating in configuration policies](#templating-in-configuration-policies) topic for advanced templating
+use cases with `ConfigurationPolicy`.
 
-When the `Policy` is bound to a [`Placement`](/concepts/placement), the `Policy` status will report
-on each cluster that matched the bound `Placement`:
+When the `Policy` is bound to a [`Placement`](/concepts/placement) using a [`PlacementBinding`](#placementbinding), the
+`Policy` status will report on each cluster that matches the bound `Placement`:
 
 ```yaml
 status:
@@ -125,11 +123,10 @@ kubectl get crd configurationpolicies.policy.open-cluster-management.io -o yaml
 
 ## PlacementBinding
 
-A `PlacementBinding` binds a [Placement](/concepts/placement) to a [`Policy`](#policy) or
-[`PolicySet`](#policyset).
+A `PlacementBinding` binds a [Placement](/concepts/placement) to a [`Policy`](#policy) or [`PolicySet`](#policyset).
 
-Below is an example of a `PlacementBinding` that binds the `policy-namespace` `Policy` to the
-`placement-hub-cluster` `Placement`.
+Below is an example of a `PlacementBinding` that binds the `policy-namespace` `Policy` to the `placement-hub-cluster`
+`Placement`.
 
 ```yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -147,19 +144,17 @@ subjects:
     name: policy-namespace
 ```
 
-Once the `Policy` is bound, it will be distributed to and acted upon by the managed clusters that
-match the `Placement`.
+Once the `Policy` is bound, it will be distributed to and acted upon by the managed clusters that match the `Placement`.
 
 ## PolicySet
 
-A `PolicySet` is a grouping mechanism of [`Policy`](#policy) objects. Compliance of all grouped
-`Policy` objects is summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its
-distribution is controlled by a [Placement](/concepts/placement) when bound through a
-[`PlacementBinding`](#placementbinding).
+A `PolicySet` is a grouping mechanism of [`Policy`](#policy) objects. Compliance of all grouped `Policy` objects is
+summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its distribution is controlled by a
+[Placement](/concepts/placement) when bound through a [`PlacementBinding`](#placementbinding).
 
-This enables a workflow where subject matter experts write `Policy` objects and then an IT
-administrator creates a `PolicySet` that groups the previously written `Policy` objects and binds
-the `PolicySet` to a `Placement` that deploys the `PolicySet`.
+This enables a workflow where subject matter experts write `Policy` objects and then an IT administrator creates a
+`PolicySet` that groups the previously written `Policy` objects and binds the `PolicySet` to a `Placement` that deploys
+the `PolicySet`.
 
 An example of a `PolicySet` is shown below.
 
@@ -170,91 +165,104 @@ metadata:
   name: acm-hardening
   namespace: policies
 spec:
-  description:
-    Apply standard best practices for hardening your Open Cluster Management installation.
+  description: Apply standard best practices for hardening your Open Cluster Management installation.
   policies:
     - policy-check-backups
     - policy-managedclusteraddon-available
     - policy-subscriptions
 ```
 
-## Policy Templates
+## Managed cluster policy controllers
 
-Configuration policies support the inclusion of Golang text templates in the object definitions.
-These templates are resolved at runtime either on the hub cluster or the target managed cluster
-using configurations related to that cluster. This gives you the ability to define configuration
-policies with dynamic content and to inform or enforce Kubernetes resources that are customized to
-the target cluster.
+The [`Policy`](#policy) on the hub delivers the policies defined in `spec.policy-templates` to the managed clusters via
+the policy framework controllers. Once on the managed cluster, these _Policy Templates_ are acted upon by the associated
+controller on the managed cluster. The policy framework supports delivering the _Policy Template_ kinds listed here:
 
-The template syntax must follow the Golang template language specification, and the resource
-definition generated from the resolved template must be a valid YAML. (See the
-[Golang documentation about package templates](https://golang.org/pkg/text/template/) for more
-information.) Any errors in template validation appear as policy violations. When you use a custom
-template function, the values are replaced at runtime.
+- Configuration policy
 
-Template functions, such as resource-specific and generic `lookup` template functions, are available
-for referencing Kubernetes resources on the hub cluster (using the `{{hub ... hub}}` delimiters), or
-managed cluster (using the `{{ ... }}` delimiters). See the
-[Hub cluster templates section](#hub-cluster-templates) for more details. The resource-specific
-functions are used for convenience and makes content of the resources more accessible. If you use
-the generic function, `lookup`, which is more advanced, it is best to be familiar with the YAML
-structure of the resource that is being looked up. In addition to these functions, utility functions
-like `base64encode`, `base64decode`, `indent`, `autoindent`, `toInt`, and `toBool` are also
-available.
+  The `ConfigurationPolicy` is provided by OCM and defines Kubernetes manifests to compare with objects that currently
+  exist on the cluster. The action that the `ConfigurationPolicy` will take is determined by its `complianceType`.
+  Compliance types include `musthave`, `mustnothave`, and `mustonlyhave`. `musthave` means the object should have the
+  listed keys and values as a subset of the larger object. `mustnothave` means an object matching the listed keys and
+  values should not exist. `mustonlyhave` ensures objects only exist with the keys and values exactly as defined. See
+  the page on [Configuration Policy](/getting-started/integration/policy-controllers/configuration-policy) for more
+  information.
 
-To conform templates with YAML syntax, templates must be set in the policy resource as strings using
-quotes or a block character (`|` or `>`). This causes the resolved template value to also be a
-string. To override this, consider using `toInt` or `toBool` as the final function in the template
-to initiate further processing that forces the value to be interpreted as an integer or boolean
-respectively.
+- Open Policy Agent Gatekeeper
+
+  Gatekeeper is a validating webhook with auditing capabilities that can enforce custom resource definition-based
+  policies that are run with the Open Policy Agent (OPA). Gatekeeper `ConstraintTemplates` and constraints can be
+  provided in an OCM `Policy` to sync to managed clusters that have Gatekeeper installed on them. See the page on
+  [Gatekeeper integration](/getting-started/integration/policy-controllers/gatekeeper) for more information.
+
+## Templating in configuration policies
+
+Configuration policies support the inclusion of Golang text templates in the object definitions. These templates are
+resolved at runtime either on the hub cluster or the target managed cluster using configurations related to that
+cluster. This gives you the ability to define configuration policies with dynamic content and to inform or enforce
+Kubernetes resources that are customized to the target cluster.
+
+The template syntax must follow the Golang template language specification, and the resource definition generated from
+the resolved template must be a valid YAML. (See the
+[Golang documentation about package templates](https://golang.org/pkg/text/template/) for more information.) Any errors
+in template validation appear as policy violations. When you use a custom template function, the values are replaced at
+runtime.
+
+Template functions, such as resource-specific and generic `lookup` template functions, are available for referencing
+Kubernetes resources on the hub cluster (using the `{{hub ... hub}}` delimiters), or managed cluster (using the
+`{{ ... }}` delimiters). See the [Hub cluster templates section](#hub-cluster-templates) for more details. The
+resource-specific functions are used for convenience and makes content of the resources more accessible. If you use the
+generic function, `lookup`, which is more advanced, it is best to be familiar with the YAML structure of the resource
+that is being looked up. In addition to these functions, utility functions like `base64encode`, `base64decode`,
+`indent`, `autoindent`, `toInt`, and `toBool` are also available.
+
+To conform templates with YAML syntax, templates must be set in the policy resource as strings using quotes or a block
+character (`|` or `>`). This causes the resolved template value to also be a string. To override this, consider using
+`toInt` or `toBool` as the final function in the template to initiate further processing that forces the value to be
+interpreted as an integer or boolean respectively.
 
 To bypass template processing you can either:
 
-- Override a single template by wrapping the template in additional braces. For example, the
-  template `{{ template content }}` would become `{{ '{{ template content }}' }}`.
+- Override a single template by wrapping the template in additional braces. For example, the template
+  `{{ template content }}` would become `{{ '{{ template content }}' }}`.
 - Override all templates in a `ConfigurationPolicy` by adding the
-  `policy.open-cluster-management.io/disable-templates: "true"` annotation in the
-  `ConfigurationPolicy` section of your `Policy`. Template processing will be bypassed for that
-  `ConfigurationPolicy`.
+  `policy.open-cluster-management.io/disable-templates: "true"` annotation in the `ConfigurationPolicy` section of your
+  `Policy`. Template processing will be bypassed for that `ConfigurationPolicy`.
 
-### Hub cluster templates
+### Hub cluster templating in configuration policies
 
-Hub cluster templates are used to define configuration policies that are dynamically customized to
-the target cluster. This reduces the need to create separate policies for each target cluster or
-hardcode configuration values in the policy definitions.
+Hub cluster templates are used to define configuration policies that are dynamically customized to the target cluster.
+This reduces the need to create separate policies for each target cluster or hardcode configuration values in the policy
+definitions.
 
-Hub cluster templates are based on Golang text template specifications, and the `{{hub … hub}}`
-delimiter indicates a hub cluster template in a configuration policy.
+Hub cluster templates are based on Golang text template specifications, and the `{{hub … hub}}` delimiter indicates a
+hub cluster template in a configuration policy.
 
-A configuration policy definition can contain both hub cluster and managed cluster templates. Hub
-cluster templates are processed first on the hub cluster, then the policy definition with resolved
-hub cluster templates is propagated to the target clusters. On the managed cluster, the
-Configuration Policy controller processes any managed cluster templates in the policy definition and
-then enforces or verifies the fully resolved object definition.
+A configuration policy definition can contain both hub cluster and managed cluster templates. Hub cluster templates are
+processed first on the hub cluster, then the policy definition with resolved hub cluster templates is propagated to the
+target clusters. On the managed cluster, the Configuration Policy controller processes any managed cluster templates in
+the policy definition and then enforces or verifies the fully resolved object definition.
 
-In OCM versions 0.9.x and older, policies are processed on the hub cluster only upon creation or
-after an update. Therefore, hub cluster templates are only resolved to the data in the referenced
-resources upon policy creation or update. Any changes to the referenced resources are not
-automatically synced to the policies.
+In OCM versions 0.9.x and older, policies are processed on the hub cluster only upon creation or after an update.
+Therefore, hub cluster templates are only resolved to the data in the referenced resources upon policy creation or
+update. Any changes to the referenced resources are not automatically synced to the policies.
 
-A special annotation, `policy.open-cluster-management.io/trigger-update` can be used to indicate
-changes to the data referenced by the templates. Any change to the special annotation value
-initiates template processing, and the latest contents of the referenced resource are read and
-updated in the policy definition that is the propagator for processing on managed clusters. A
-typical way to use this annotation is to increment the value by one each time.
+A special annotation, `policy.open-cluster-management.io/trigger-update` can be used to indicate changes to the data
+referenced by the templates. Any change to the special annotation value initiates template processing, and the latest
+contents of the referenced resource are read and updated in the policy definition that is the propagator for processing
+on managed clusters. A typical way to use this annotation is to increment the value by one each time.
 
-### Template encryption details
+### Templating value encryption
 
-The encryption algorithm uses AES-CBC with 256-bit keys. Each encryption key is unique per managed
-cluster and is automatically rotated every 30 days. This ensures that your decrypted value is never
-stored in the policy on the managed cluster.
+The encryption algorithm uses AES-CBC with 256-bit keys. Each encryption key is unique per managed cluster and is
+automatically rotated every 30 days. This ensures that your decrypted value is never stored in the policy on the managed
+cluster.
 
-To force an immediate encryption key rotation, delete the
-`policy.open-cluster-management.io/last-rotated` annotation on the `policy-encryption-key` Secret in
-the managed cluster namespace on the hub cluster. Policies are then reprocessed to use the new
-encryption key.
+To force an immediate encryption key rotation, delete the `policy.open-cluster-management.io/last-rotated` annotation on
+the `policy-encryption-key` Secret in the managed cluster namespace on the hub cluster. Policies are then reprocessed to
+use the new encryption key.
 
-### Template functions
+### Templating functions
 
 | Function           | Description                                                                                                                                                                                                         | Sample                                                                                                                                       |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -270,8 +278,7 @@ encryption key.
 | `toBool`           | Returns the boolean value of the input string and ensures that the value is interpreted as a boolean in the YAML.                                                                                                   | `enabled: \|`<br />`{{ (fromConfigMap "site-config" "site1" "enabled") \| toBool }}`                                                         |
 | `protect`          | Encrypts the input string. It is decrypted when the policy is evaluated. On the replicated policy in the managed cluster namespace, the resulting value resembles the following: `$ocm_encrypted:<encrypted-value>` | `enabled: \|`<br />`{{hub "(lookup "route.openshift.io/v1" "Route" "openshift-authentication" "oauth-openshift").spec.host \| protect hub}}` |
 
-Additionally, OCM supports the following template functions that are included from the `sprig` open
-source project:
+Additionally, OCM supports the following template functions that are included from the `sprig` open source project:
 
 - `cat`
 - `contains`

--- a/content/zh/getting-started/integration/policy-controllers/_index.md
+++ b/content/zh/getting-started/integration/policy-controllers/_index.md
@@ -1,0 +1,29 @@
+---
+title: Policy controllers
+weight: 10
+---
+
+The [Policy API](/concepts/policy) on the hub delivers the policies defined in `spec.policy-templates` to the managed
+clusters via the [policy framework controllers](/getting-started/integration/policy-framework). Once on the managed
+cluster, these _Policy Templates_ are acted upon by the associated controller on the managed cluster. The policy
+framework supports delivering the _Policy Template_ kinds listed.
+
+<!-- spellchecker-disable -->
+
+{{< toc >}}
+
+<!-- spellchecker-enable -->
+
+## [Configuration policy](/getting-started/integration/policy-controllers/configuration-policy)
+
+  The `ConfigurationPolicy` is provided by OCM and defines Kubernetes manifests to compare with objects that currently
+  exist on the cluster. The action that the `ConfigurationPolicy` will take is determined by its `complianceType`.
+  Compliance types include `musthave`, `mustnothave`, and `mustonlyhave`. `musthave` means the object should have the
+  listed keys and values as a subset of the larger object. `mustnothave` means an object matching the listed keys and
+  values should not exist. `mustonlyhave` ensures objects only exist with the keys and values exactly as defined.
+
+## [Open Policy Agent Gatekeeper](/getting-started/integration/policy-controllers/gatekeeper)
+
+  Gatekeeper is a validating webhook with auditing capabilities that can enforce custom resource definition-based
+  policies that are run with the Open Policy Agent (OPA). Gatekeeper `ConstraintTemplates` and constraints can be
+  provided in an OCM `Policy` to sync to managed clusters that have Gatekeeper installed on them.

--- a/content/zh/getting-started/integration/policy-controllers/configuration-policy.md
+++ b/content/zh/getting-started/integration/policy-controllers/configuration-policy.md
@@ -1,9 +1,10 @@
 ---
-title: Policy controllers
-weight: 11
+title: Configuration Policy
+weight: 15
 ---
 
-After policy framework is installed, you can install the policy controllers to the managed clusters.
+The `ConfigurationPolicy` defines Kubernetes manifests to compare with objects that currently exist on the cluster. The
+Configuration policy controller is provided by Open Cluster Management and runs on managed clusters.
 
 <!-- spellchecker-disable -->
 
@@ -11,30 +12,27 @@ After policy framework is installed, you can install the policy controllers to t
 
 <!-- spellchecker-enable -->
 
-## Prerequisite
+## Prerequisites
 
-You must meet the following prerequisites to install the policy controllers:
+You must meet the following prerequisites to install the configuration policy controller:
 
 - Ensure [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) and
   [`kustomize`](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
 
-- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from
-  the source.
+- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
 
 - Ensure the `open-cluster-management` _policy framework_ is installed. See
   [Policy Framework](/getting-started/integration/policy-framework) for more information.
 
-## Install the configuration policy controller to the managed cluster(s)
+## Installing the configuration policy controller
 
 ### Deploy via Clusteradm CLI
 
 Ensure `clusteradm` CLI is installed and is newer than v0.3.0. Download and extract the
-[clusteradm binary](https://github.com/open-cluster-management-io/clusteradm/releases/latest). For
-more details see the
+[clusteradm binary](https://github.com/open-cluster-management-io/clusteradm/releases/latest). For more details see the
 [clusteradm GitHub page](https://github.com/open-cluster-management-io/clusteradm/blob/main/README.md#quick-start).
 
-1. Deploy the configuration policy controller to the managed cluster(s) (this command is the same
-   for a self-managed hub):
+1. Deploy the configuration policy controller to the managed clusters (this command is the same for a self-managed hub):
 
    ```Shell
    # Deploy the configuration policy controller
@@ -68,7 +66,7 @@ more details see the
 
    # Apply the CRD
    export COMPONENT="config-policy-controller"
-   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/${COMPONENT}/v0.9.0/deploy"
+   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/${COMPONENT}/v0.11.0/deploy"
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_configurationpolicies.yaml
 
    # Set the managed cluster name
@@ -79,9 +77,8 @@ more details see the
    kubectl set env deployment/${COMPONENT} -n ${MANAGED_NAMESPACE} --containers=${COMPONENT} WATCH_NAMESPACE=${MANAGED_CLUSTER_NAME}
    ```
 
-   - See
-     [config-policy-controller](https://github.com/open-cluster-management-io/config-policy-controller)
-     for more information.
+   - See [config-policy-controller](https://github.com/open-cluster-management-io/config-policy-controller) for more
+     information.
 
 2. Ensure the pod is running on the managed cluster with the following command:
 
@@ -91,13 +88,12 @@ more details see the
    config-policy-controller-7f8fb64d8c-pmfx4          1/1     Running   0          44s
    ```
 
-## What is next
+## Sample configuration policy
 
-After a successful deployment, test the policy framework and configuration policy controller with a
-sample policy. You can use a policy that includes a `Placement` mapping or if you installed
-Application management's `PlacementRule` support you can use either placement implementation.
-Perform the steps in the **Placement API** or the **Placement Rule API** section based on which
-placement API you desire to use.
+After a successful deployment, test the policy framework and configuration policy controller with a sample policy. You
+can use a policy that includes a `Placement` mapping or if you installed Application management's `PlacementRule`
+support you can use either placement implementation. Perform the steps in the **Placement API** or the **Placement Rule
+API** section based on which placement API you desire to use.
 
 For more information on how to use a `ConfigurationPolicy`, read the
 [`Policy` API concept section](/getting-started/integration/policy-framework#policy).
@@ -114,17 +110,17 @@ For more information on how to use a `ConfigurationPolicy`, read the
    kubectl apply -n default -f https://raw.githubusercontent.com/stolostron/policy-collection/main/community/CM-Configuration-Management/policy-pod-placement.yaml
    ```
 
-2. Update the `Placement` to distribute the policy to the managed cluster with the following command
-   (this `clusterSelector` will deploy the policy to all managed clusters):
+2. Update the `Placement` to distribute the policy to the managed cluster with the following command (this
+   `clusterSelector` will deploy the policy to all managed clusters):
 
    ```Shell
    kubectl patch -n default placement.cluster.open-cluster-management.io/placement-policy-pod --type=merge -p "{\"spec\":{\"predicates\":[{\"requiredClusterSelector\":{\"labelSelector\":{\"matchExpressions\":[]}}}]}}"
    ```
 
-3. Make sure the `default` namespace has a `ManagedClusterSetBinding` for a `ManagedClusterSet` with
-   at least one managed cluster resource in the `ManagedClusterSet`. See
-   [Bind ManagedClusterSet to a namespace](/concepts/managedclusterset#bind-managedclusterset-to-a-namespace)
-   for more information on this.
+3. Make sure the `default` namespace has a `ManagedClusterSetBinding` for a `ManagedClusterSet` with at least one
+   managed cluster resource in the `ManagedClusterSet`. See
+   [Bind ManagedClusterSet to a namespace](/concepts/managedclusterset#bind-managedclusterset-to-a-namespace) for more
+   information on this.
 
 4. To confirm that the managed cluster is selected by the `Placement`, run the following command:
 
@@ -152,16 +148,15 @@ For more information on how to use a `ConfigurationPolicy`, read the
    kubectl apply -n default -f https://raw.githubusercontent.com/open-cluster-management/policy-collection/main/stable/CM-Configuration-Management/policy-pod.yaml
    ```
 
-2. Update the `PlacementRule` to distribute the policy to the managed cluster with the following
-   command (this `clusterSelector` will deploy the policy to all managed clusters):
+2. Update the `PlacementRule` to distribute the policy to the managed cluster with the following command (this
+   `clusterSelector` will deploy the policy to all managed clusters):
 
    ```Shell
    $ kubectl patch -n default placementrule.apps.open-cluster-management.io/placement-policy-pod --type=merge -p "{\"spec\":{\"clusterSelector\":{\"matchExpressions\":[]}}}"
    placementrule.apps.open-cluster-management.io/placement-policy-pod patched
    ```
 
-3. To confirm that the managed cluster is selected by the `PlacementRule`, run the following
-   command:
+3. To confirm that the managed cluster is selected by the `PlacementRule`, run the following command:
 
    ```Shell
    $ kubectl get -n default placementrule.apps.open-cluster-management.io/placement-policy-pod -o yaml
@@ -175,19 +170,18 @@ For more information on how to use a `ConfigurationPolicy`, read the
 
 ### Final steps to apply the policy
 
-Perform the following steps to continue working with the policy to test the policy framework now
-that a placement method has been selected between `Placement` or `PlacementRule`.
+Perform the following steps to continue working with the policy to test the policy framework now that a placement method
+has been selected between `Placement` or `PlacementRule`.
 
-1. Enforce the policy to make the configuration policy automatically correct any misconfigurations
-   on the managed cluster:
+1. Enforce the policy to make the configuration policy automatically correct any misconfigurations on the managed
+   cluster:
 
    ```Shell
    $ kubectl patch -n default policy.policy.open-cluster-management.io/policy-pod --type=merge -p "{\"spec\":{\"remediationAction\": \"enforce\"}}"
    policy.policy.open-cluster-management.io/policy-pod patched
    ```
 
-2. After a few seconds, your policy is propagated to the managed cluster. To confirm, run the
-   following command:
+2. After a few seconds, your policy is propagated to the managed cluster. To confirm, run the following command:
 
    ```Shell
    $ kubectl config use-context ${CTX_MANAGED_CLUSTER}
@@ -196,8 +190,8 @@ that a placement method has been selected between `Placement` or `PlacementRule`
    cluster1    default.policy-pod   enforce              Compliant          4m32s
    ```
 
-3. The missing pod is created by the policy on the managed cluster. To confirm, run the following
-   command on the managed cluster:
+3. The missing pod is created by the policy on the managed cluster. To confirm, run the following command on the managed
+   cluster:
 
    ```Shell
    $ kubectl get pod -n default

--- a/content/zh/getting-started/integration/policy-controllers/gatekeeper.md
+++ b/content/zh/getting-started/integration/policy-controllers/gatekeeper.md
@@ -1,0 +1,135 @@
+---
+title: Open Policy Agent Gatekeeper
+weight: 15
+---
+
+[Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/) is a validating webhook with auditing capabilities
+that can enforce custom resource definition-based policies that are run with the Open Policy Agent (OPA). Gatekeeper
+constraints can be used to evaluate Kubernetes resource compliance. You can leverage OPA as the policy engine, and use
+Rego as the policy language.
+
+<!-- spellchecker-disable -->
+
+{{< toc >}}
+
+<!-- spellchecker-enable -->
+
+## Installing Gatekeeper
+
+See the [Gatekeeper documentation](https://open-policy-agent.github.io/gatekeeper/website/docs/install) to install the
+desired version of Gatekeeper to the managed cluster.
+
+## Sample Gatekeeper policy
+
+Gatekeeper policies are written using constraint templates and constraints. View the following YAML examples that use
+Gatekeeper constraints in an OCM `Policy`:
+
+- `ConstraintTemplates` and constraints: Use the Gatekeeper integration feature by using OCM policies for multicluster
+  distribution of Gatekeeper constraints and Gatekeeper audit results aggregation on the hub cluster. The following
+  example defines a Gatekeeper `ConstraintTemplate` and constraint (`K8sRequiredLabels`) to ensure the "gatekeeper"
+  label is set on all namespaces:
+
+  ```yaml
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  metadata:
+    name: require-gatekeeper-labels-on-ns
+  spec:
+    remediationAction: inform # (1)
+    disabled: false
+    policy-templates:
+      - objectDefinition:
+          apiVersion: templates.gatekeeper.sh/v1beta1
+          kind: ConstraintTemplate
+          metadata:
+            name: k8srequiredlabels
+          spec:
+            crd:
+              spec:
+                names:
+                  kind: K8sRequiredLabels
+                validation:
+                  openAPIV3Schema:
+                    properties:
+                      labels:
+                        type: array
+                        items: string
+            targets:
+              - target: admission.k8s.gatekeeper.sh
+                rego: |
+                  package k8srequiredlabels
+                  violation[{"msg": msg, "details": {"missing_labels": missing}}] {
+                    provided := {label | input.review.object.metadata.labels[label]}
+                    required := {label | label := input.parameters.labels[_]}
+                    missing := required - provided
+                    count(missing) > 0
+                    msg := sprintf("you must provide labels: %v", [missing])
+                  }
+      - objectDefinition:
+          apiVersion: constraints.gatekeeper.sh/v1beta1
+          kind: K8sRequiredLabels
+          metadata:
+            name: ns-must-have-gk
+          spec:
+            enforcementAction: dryrun
+            match:
+              kinds:
+                - apiGroups: [""]
+                  kinds: ["Namespace"]
+            parameters:
+              labels: ["gatekeeper"]
+  ```
+
+  1. Since the remediationAction is set to "inform", the `enforcementAction` field of the Gatekeeper constraint is
+     overridden to "warn". This means that Gatekeeper detects and warns you about creating or updating a namespace that
+     is missing the "gatekeeper" label. If the policy `remediationAction` is set to "enforce", the Gatekeeper constraint
+     `enforcementAction` field is overridden to "deny". In this context, this configuration prevents any user from
+     creating or updating a namespace that is missing the gatekeeper label.
+
+  With the previous policy, you might receive the following policy status message:
+
+  > warn - you must provide labels: {"gatekeeper"} (on Namespace default); warn - you must provide labels:
+  > {"gatekeeper"} (on Namespace gatekeeper-system).
+
+  Once a policy containing Gatekeeper constraints or `ConstraintTemplates` is deleted, the constraints and
+  `ConstraintTemplates` are also deleted from the managed cluster.
+
+  **Notes:**
+
+  - The Gatekeeper audit functionality runs every minute by default. Audit results are sent back to the hub cluster to
+    be viewed in the OCM policy status of the managed cluster.
+
+- Auditing Gatekeeper events: The following example uses an OCM
+  [configuration policy](getting-started/integration/configuration-policy) within an OCM policy to check for Kubernetes
+  API requests denied by the Gatekeeper admission webhook:
+
+  ```yaml
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  metadata:
+    name: policy-gatekeeper-admission
+  spec:
+    remediationAction: inform
+    disabled: false
+    policy-templates:
+      - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-gatekeeper-admission
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: low
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: v1
+                kind: Event
+                metadata:
+                  namespace: gatekeeper-system # set it to the actual namespace where gatekeeper is running if different
+                  annotations:
+                    constraint_action: deny
+                    constraint_kind: K8sRequiredLabels
+                    constraint_name: ns-must-have-gk
+                    event_type: violation
+  ```

--- a/content/zh/getting-started/integration/policy-framework.md
+++ b/content/zh/getting-started/integration/policy-framework.md
@@ -3,9 +3,8 @@ title: Policy framework
 weight: 10
 ---
 
-The policy framework provides governance capabilities to OCM managed Kubernetes clusters. Policies
-provide visibility and drive remediation for various security and configuration aspects to help IT
-administrators meet their requirements.
+The policy framework provides governance capabilities to OCM managed Kubernetes clusters. Policies provide visibility
+and drive remediation for various security and configuration aspects to help IT administrators meet their requirements.
 
 <!-- spellchecker-disable -->
 
@@ -15,8 +14,8 @@ administrators meet their requirements.
 
 ## API Concepts
 
-View the [Policy API](/concepts/policy) page for additional details about the Policy API managed by
-the Policy Framework components, including:
+View the [Policy API](/concepts/policy) page for additional details about the Policy API managed by the Policy Framework
+components, including:
 
 - [`Policy`](/concepts/policy#policy)
 - [`PolicySet`](/concepts/policy#policyset)
@@ -28,8 +27,8 @@ the Policy Framework components, including:
    <img src="/policy-framework-architecture-diagram.jpg" alt="Policy framework architecture" style="margin: 0 auto; width: 80%">
 </div>
 
-The governance policy framework distributes policies to managed clusters and collects results to
-send back to the hub cluster.
+The governance policy framework distributes policies to managed clusters and collects results to send back to the hub
+cluster.
 
 - [Policy propagator](https://github.com/open-cluster-management-io/governance-policy-propagator)
 - [Policy framework addon](https://github.com/open-cluster-management-io/governance-policy-framework-addon)
@@ -48,19 +47,18 @@ You must meet the following prerequisites to install the policy framework:
 - Ensure [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) and
   [`kustomize`](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
 
-- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from
-  the source.
+- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
 
-- Ensure the `open-cluster-management` _cluster manager_ is installed. [Start the control plane](/getting-started/installation/start-the-control-plane) for more information.
+- Ensure the `open-cluster-management` _cluster manager_ is installed. See
+  [Start the control plane](/getting-started/installation/start-the-control-plane) for more information.
 
 - Ensure the `open-cluster-management` _klusterlet_ is installed. See
   [Register a cluster](/getting-started/installation/register-a-cluster) for more information.
 
-- If you are using `PlacementRules` with your policies, ensure the `open-cluster-management`
-  _application_ is installed . See
-  [Application management](/getting-started/integration/app-lifecycle) for more information. If you
-  are using the default `Placement` API, you can skip the Application management installation, but
-  you do need to install the `PlacementRule` CRD with this command:
+- If you are using `PlacementRules` with your policies, ensure the `open-cluster-management` _application_ is installed
+  . See [Application management](/getting-started/integration/app-lifecycle) for more information. If you are using the
+  default `Placement` API, you can skip the Application management installation, but you do need to install the
+  `PlacementRule` CRD with this command:
 
   ```Shell
   kubectl apply -f https://raw.githubusercontent.com/open-cluster-management-io/multicloud-operators-subscription/main/deploy/hub-common/apps.open-cluster-management.io_placementrules_crd.yaml
@@ -71,8 +69,7 @@ You must meet the following prerequisites to install the policy framework:
 ### Install via Clusteradm CLI
 
 Ensure `clusteradm` CLI is installed and is at least v0.3.0. Download and extract the
-[clusteradm binary](https://github.com/open-cluster-management-io/clusteradm/releases/latest). For
-more details see the
+[clusteradm binary](https://github.com/open-cluster-management-io/clusteradm/releases/latest). For more details see the
 [clusteradm GitHub page](https://github.com/open-cluster-management-io/clusteradm/blob/main/README.md#quick-start).
 
 1. Deploy the policy framework controllers to the hub cluster:
@@ -105,8 +102,8 @@ more details see the
 
 ### Install from source
 
-1. Deploy the policy Custom Resource Definitions (CRD) and policy propagator component to the
-   `open-cluster-management` namespace on the hub cluster with the following commands:
+1. Deploy the policy Custom Resource Definitions (CRD) and policy propagator component to the `open-cluster-management`
+   namespace on the hub cluster with the following commands:
 
    ```Shell
    # Configure kubectl to point to the hub cluster
@@ -123,7 +120,7 @@ more details see the
    export HUB_KUBECONFIG="hub-kubeconfig"
 
    # Apply the CRDs
-   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.9.0/deploy"
+   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.11.0/deploy"
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policies.yaml
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_placementbindings.yaml
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policyautomations.yaml
@@ -171,8 +168,8 @@ more details see the
    governance-policy-framework-addon-57579b7c-652zj         1/1     Running   0          87s
    ```
 
-   **NOTE**: If you are using clusteradm v0.3.x or older, the pod will be called `governance-policy-framework` and
-   have a container per synchronization component (2 on a self-managed Hub, or 3 on a managed cluster).
+   **NOTE**: If you are using clusteradm v0.3.x or older, the pod will be called `governance-policy-framework` and have
+   a container per synchronization component (2 on a self-managed Hub, or 3 on a managed cluster).
 
 ### Deploy from source
 
@@ -213,7 +210,7 @@ more details see the
 
    # Apply the policy CRD
    export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io"
-   kubectl apply -f ${GIT_PATH}/governance-policy-propagator/v0.9.0/deploy/crds/policy.open-cluster-management.io_policies.yaml
+   kubectl apply -f ${GIT_PATH}/governance-policy-propagator/v0.11.0/deploy/crds/policy.open-cluster-management.io_policies.yaml
 
    # Set the managed cluster name and create the namespace
    export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
@@ -221,7 +218,7 @@ more details see the
 
    # Deploy the synchronization component
    export COMPONENT="governance-policy-framework-addon"
-   kubectl apply -f ${GIT_PATH}/${COMPONENT}/v0.9.0/deploy/operator.yaml -n ${MANAGED_NAMESPACE}
+   kubectl apply -f ${GIT_PATH}/${COMPONENT}/v0.11.0/deploy/operator.yaml -n ${MANAGED_NAMESPACE}
    kubectl patch deployment governance-policy-framework-addon -n ${MANAGED_NAMESPACE} \
      -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"governance-policy-framework-addon\",\"args\":[\"--hub-cluster-configfile=/var/run/klusterlet/kubeconfig\", \"--cluster-namespace=${MANAGED_CLUSTER_NAME}\", \"--enable-lease=true\", \"--log-level=2\", \"--disable-spec-sync=${DEPLOY_ON_HUB}\"]}]}}}}"
    ```


### PR DESCRIPTION
- Adds Gatekeeper references now that Policies can sync Gatekeeper manifests directly
- Also cleans up and reflows the Policy doc to make it all fit together

ref: https://issues.redhat.com/browse/ACM-5932

/cc @JustinKuli @mprahl @gparvin @yiraeChristineKim 