### PR TITLE
Add syntax highlighting in clusterclaim

### DIFF
--- a/content/en/concepts/clusterclaim.md
+++ b/content/en/concepts/clusterclaim.md
@@ -32,7 +32,7 @@ to the status of `ManagedCluster`.
 
 Here is a `ClusterClaim` example specifying a `id.k8s.io`:
 
-```
+```yaml
 apiVersion: cluster.open-cluster-management.io/v1alpha1
 kind: ClusterClaim
 metadata:
@@ -44,7 +44,7 @@ spec:
 After applying the `ClusterClaim` above to any managed cluster, the value of the `ClusterClaim` 
 is reflected in the `ManagedCluster` on the hub cluster:
 
-```
+```yaml
 apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata: ...


### PR DESCRIPTION
While reviewing the aforementioned article, I discerned a deficiency in Syntax highlighting implementation. 
Syntax highlighting entails the alteration of color and style attributes of source code, thereby enhancing its readability. Consequently, I undertook a comprehensive revision of all `YAML` files within the `ClusterClaim` article, integrating Syntax highlighting. 
This augmentation was executed with the primary objective of rendering the article content more accessible and comprehensible to its readership.