### PR TITLE
Add `clusteradm` install to "Quick Start"

### DIFF
--- a/content/en/getting-started/quick-start/_index.md
+++ b/content/en/getting-started/quick-start/_index.md
@@ -12,6 +12,14 @@ weight: 1
 - Ensure [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
 - Ensure [kind](https://kind.sigs.k8s.io/)(greater than `v0.9.0+`, or the latest version is preferred) is installed.
 
+## Install clusteradm CLI tool
+
+Run the following command to download and install the latest `clusteradm` command-line tool:
+
+```shell
+curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+```
+
 ## Setup hub and managed cluster
 
 Run the following command to quickly setup a hub cluster and 2 managed clusters by kind.


### PR DESCRIPTION
I'm not sure why it's missing here since it's a prerequisite for the script...

If it looks good, I'll also need someone to help translate it over to the equivalent `zh` page since that page has been translated already.