### PR TITLE
refine the website structure

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -22,27 +22,27 @@ title: Open Cluster Management
 {{< /blocks/cover >}}
 
 {{% blocks/section color="secondary" type="row" title="Features Overview" %}}
-  {{% blocks/feature icon="fa-server" title="Cluster Inventory" %}}
+  {{% blocks/feature icon="fa-server" title="Cluster Inventory" url="docs/concepts/cluster-inventory/" %}}
   Registration of multiple clusters to a hub cluster to place them for management.
   {{% /blocks/feature %}}
 
-  {{% blocks/feature icon="fa-tasks" title="Work Distribution" %}}
+  {{% blocks/feature icon="fa-tasks" title="Work Distribution" url="docs/concepts/work-distribution/" %}}
   The work API that enables resources to be applied to managed clusters from a hub cluster.
   {{% /blocks/feature %}}
 
-  {{% blocks/feature icon="fa-random" title="Content placement" %}}
+  {{% blocks/feature icon="fa-random" title="Content Placement" url="docs/concepts/content-placement/" %}}
   Dynamic placement of content and behavior across multiple clusters.
   {{% /blocks/feature %}}
 
-  {{% blocks/feature icon="fa-cloud" title="Vendor neutral APIs" %}}
+  {{% blocks/feature icon="fa-cloud" title="Vendor Neutral APIs" %}}
   Avoid vendor lock-in by using APIs that are not tied to any cloud providers or proprietary platforms.
   {{% /blocks/feature %}}
 
-  {{% blocks/feature icon="fa-rocket" title="Launch apps everywhere" url="docs/getting-started/integration/app-lifecycle/" %}}
+  {{% blocks/feature icon="fa-rocket" title="Launch Apps Everywhere" url="docs/getting-started/integration/app-lifecycle/" %}}
   Use application lifecycle to create your application and deliver hybrid apps across one or more clusters, while you keep up with changes.
   {{% /blocks/feature %}}
 
-  {{% blocks/feature icon="fa-cog" title="Configure, secure, and manage your resources." url="docs/concepts/policy" %}}
+  {{% blocks/feature icon="fa-cog" title="Configure, Secure, and Manage Your Resources" url="docs/getting-started/integration/policy" %}}
   Policy and configuration management uses labels to help you deploy policies and control consistently across your resources. Keep your resources secure by using access control and manage for your quota and cost.
   {{% /blocks/feature %}}
 {{% /blocks/section %}}

--- a/content/en/blog/access-cluster-in-different-vps/index.md
+++ b/content/en/blog/access-cluster-in-different-vps/index.md
@@ -121,7 +121,7 @@ default-token-r89gs   kubernetes.io/service-account-token   3      6d22h
 dep                   Opaque                                2      6d21h
 ```
 
-接着，管理员需要通过OCM的[Manifestwork]({{< ref "docs/concepts/manifestwork" >}}), 即工作负载分发功能，在cluster1上创建一个`ClusterRole`，给dep绑定了cluster1上的对应权限：
+接着，管理员需要通过OCM的[Manifestwork]({{< ref "docs/concepts/work-distribution/manifestwork" >}}), 即工作负载分发功能，在cluster1上创建一个`ClusterRole`，给dep绑定了cluster1上的对应权限：
 
 ```bash
 # 创建ClusterRole, 仅具有操作Deployment的权限

--- a/content/en/docs/concepts/add-on-extensibility/_index.md
+++ b/content/en/docs/concepts/add-on-extensibility/_index.md
@@ -1,0 +1,4 @@
+---
+title: Add-On Extensibility
+weight: 5
+---

--- a/content/en/docs/concepts/add-on-extensibility/addon.md
+++ b/content/en/docs/concepts/add-on-extensibility/addon.md
@@ -1,6 +1,9 @@
 ---
 title: Add-ons
-weight: 8
+weight: 1
+aliases:
+  - /concepts/addon/
+  - /docs/concepts/addon/
 ---
 
 

--- a/content/en/docs/concepts/architecture.md
+++ b/content/en/docs/concepts/architecture.md
@@ -72,7 +72,7 @@ for registering a new cluster to the hub. Any cluster that can reach the
 endpoint of the hub cluster will be able to be managed, even a random KinD
 sandbox cluster on your laptop. That is because the prescriptions are
 effectively __pulled__ from the hub instead of __pushing__. In addition to
-that, OCM also provides a [addon]({{< ref "docs/concepts/addon" >}})
+that, OCM also provides a [addon]({{< ref "docs/concepts/add-on-extensibility/addon" >}})
 named ["cluster-proxy"]({{< ref "docs/getting-started/integration/cluster-proxy" >}})
 which automatically manages a reverse proxy tunnel for proactive access to the
 managed clusters by leveraging on the Kubernetes' subproject [konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/).
@@ -88,7 +88,7 @@ building blocks, except for the mandatory core module named [registration](https
 which is responsible for controlling the lifecycle of a managed controller
 and exporting the elementary `ManagedCluster` model.
 
-Another good example surfacing our modularity will be the [placement]({{< ref "docs/concepts/placement" >}}),
+Another good example surfacing our modularity will be the [placement]({{< ref "docs/concepts/content-placement/placement" >}}),
 a standalone module focusing at dynamically selecting the proper list of
 the managed clusters from the user's prescription. You can build any advanced
 multi-cluster orchestration on the top of placement, e.g. multi-cluster
@@ -155,7 +155,7 @@ Addon is a general concept for the optional, pluggable customization built over
 the extensibility from OCM. It can be a controller in the hub cluster, or just
 a customized agent in the managed cluster, or even the both collaborating
 in peers. The addons are expected to implement the `ClusterManagementAddon` or
-`ManagedClusterAddOn` API of which a detailed elaboration can be found [here]({{< ref "docs/concepts/addon" >}}).
+`ManagedClusterAddOn` API of which a detailed elaboration can be found [here]({{< ref "docs/concepts/add-on-extensibility/addon" >}}).
 
 ---
 
@@ -179,7 +179,7 @@ probing each other's healthiness. i.e. the cluster heartbeats.
 
 The module for dispatching resources from the hub cluster to the managed
 clusters, which can be easily done by writing a `ManifestWork` resource into
-a cluster namespace. See more details about the API [here]({{< ref "docs/concepts/manifestwork" >}}).
+a cluster namespace. See more details about the API [here]({{< ref "docs/concepts/work-distribution/manifestwork" >}}).
 
 ### Placement
 

--- a/content/en/docs/concepts/cluster-inventory/_index.md
+++ b/content/en/docs/concepts/cluster-inventory/_index.md
@@ -1,0 +1,4 @@
+---
+title: Cluster Inventory
+weight: 2
+---

--- a/content/en/docs/concepts/cluster-inventory/clusterclaim.md
+++ b/content/en/docs/concepts/cluster-inventory/clusterclaim.md
@@ -1,6 +1,9 @@
 ---
 title: ClusterClaim
-weight: 2
+weight: 1
+aliases:
+  - /concepts/clusterclaim/
+  - /docs/concepts/clusterclaim/
 ---
 
 

--- a/content/en/docs/concepts/cluster-inventory/managedcluster.md
+++ b/content/en/docs/concepts/cluster-inventory/managedcluster.md
@@ -1,6 +1,9 @@
 ---
 title: ManagedCluster
-weight: 3
+weight: 2
+aliases:
+  - /concepts/managedcluster/
+  - /docs/concepts/managedcluster/
 ---
 
 
@@ -69,7 +72,7 @@ $ clusteradm accept --clusters <cluster name>
 Upon the approval, the registration agent will observe the signed certificate
 and persist them as a local secret named "hub-kubeconfig-secret" (by default
 in the "open-cluster-management-agent" namespace) which will be mounted to the
-other fundamental components of klusterlet such as the [work]({{< ref "docs/concepts/manifestwork" >}})
+other fundamental components of klusterlet such as the [work]({{< ref "docs/concepts/work-distribution/manifestwork" >}})
 agent. In a word, if you can find your "hub-kubeconfig-secret" successfully
 present in your managed cluster, the cluster registration is all set!
 

--- a/content/en/docs/concepts/cluster-inventory/managedclusterset.md
+++ b/content/en/docs/concepts/cluster-inventory/managedclusterset.md
@@ -1,6 +1,9 @@
 ---
 title: ManagedClusterSet
-weight: 4
+weight: 3
+aliases:
+  - /concepts/managedclusterset/
+  - /docs/concepts/managedclusterset/
 ---
 
 

--- a/content/en/docs/concepts/content-placement/_index.md
+++ b/content/en/docs/concepts/content-placement/_index.md
@@ -1,0 +1,4 @@
+---
+title: Content Placement
+weight: 4
+---

--- a/content/en/docs/concepts/content-placement/placement.md
+++ b/content/en/docs/concepts/content-placement/placement.md
@@ -1,6 +1,9 @@
 ---
 title: Placement
-weight: 5
+weight: 1
+aliases:
+  - /concepts/placement/
+  - /docs/concepts/placement/
 ---
 
 

--- a/content/en/docs/concepts/work-distribution/_index.md
+++ b/content/en/docs/concepts/work-distribution/_index.md
@@ -1,0 +1,4 @@
+---
+title: Work Distribution
+weight: 3
+---

--- a/content/en/docs/concepts/work-distribution/manifestwork.md
+++ b/content/en/docs/concepts/work-distribution/manifestwork.md
@@ -1,8 +1,9 @@
 ---
 title: ManifestWork
-weight: 6
+weight: 1
 aliases:
   - /concepts/manifestwork/
+  - /docs/concepts/manifestwork/
 ---
 
 

--- a/content/en/docs/concepts/work-distribution/manifestworkreplicaset.md
+++ b/content/en/docs/concepts/work-distribution/manifestworkreplicaset.md
@@ -1,6 +1,9 @@
 ---
 title: ManifestWorkReplicaSet
-weight: 7
+weight: 2
+aliases:
+  - /concepts/manifestworkreplicaset/
+  - /docs/concepts/manifestworkreplicaset/
 ---
 
 

--- a/content/en/docs/getting-started/integration/cluster-proxy.md
+++ b/content/en/docs/getting-started/integration/cluster-proxy.md
@@ -58,7 +58,7 @@ control plane network connectivity for us:
 
 
 Cluster proxy runs inside OCM's hub cluster as an addon manager which is
-developed based on the [Addon-Framework]({{< ref "docs/concepts/addon" >}}).
+developed based on the [Addon-Framework]({{< ref "docs/concepts/add-on-extensibility/addon" >}}).
 The addon manager of cluster proxy will be responsible for:
 
 1. Managing the installation of proxy servers in the hub cluster.

--- a/content/en/docs/getting-started/integration/multicluster-controlplane.md
+++ b/content/en/docs/getting-started/integration/multicluster-controlplane.md
@@ -1,6 +1,9 @@
 ---
 title: Multicluster Control Plane
-weight: 10
+weight: 5
+aliases:
+  - /concepts/multicluster-controlplane/
+  - /docs/concepts/multicluster-controlplane/
 ---
 
 

--- a/content/en/docs/getting-started/integration/policy-controllers/_index.md
+++ b/content/en/docs/getting-started/integration/policy-controllers/_index.md
@@ -3,7 +3,7 @@ title: Policy controllers
 weight: 10
 ---
 
-The [Policy API]({{< ref "docs/concepts/policy" >}}) on the hub delivers the policies defined in `spec.policy-templates` to the managed
+The [Policy API]({{< ref "docs/getting-started/integration/policy" >}}) on the hub delivers the policies defined in `spec.policy-templates` to the managed
 clusters via the [policy framework controllers]({{< ref "docs/getting-started/integration/policy-framework" >}}). Once on the managed
 cluster, these _Policy Templates_ are acted upon by the associated controller on the managed cluster. The policy
 framework supports delivering the _Policy Template_ kinds listed.

--- a/content/en/docs/getting-started/integration/policy-controllers/configuration-policy.md
+++ b/content/en/docs/getting-started/integration/policy-controllers/configuration-policy.md
@@ -70,7 +70,7 @@ For more information on how to use a `ConfigurationPolicy`, read the
 
 3. Make sure the `default` namespace has a `ManagedClusterSetBinding` for a `ManagedClusterSet` with at least one
    managed cluster resource in the `ManagedClusterSet`. See
-   [Bind ManagedClusterSet to a namespace]({{< ref "docs/concepts/managedclusterset#bind-managedclusterset-to-a-namespace" >}}) for more
+   [Bind ManagedClusterSet to a namespace]({{< ref "docs/concepts/cluster-inventory/managedclusterset#bind-managedclusterset-to-a-namespace" >}}) for more
    information on this.
 
 4. To confirm that the managed cluster is selected by the `Placement`, run the following command:

--- a/content/en/docs/getting-started/integration/policy-framework.md
+++ b/content/en/docs/getting-started/integration/policy-framework.md
@@ -10,12 +10,12 @@ and drive remediation for various security and configuration aspects to help IT 
 
 ## API Concepts
 
-View the [Policy API]({{< ref "docs/concepts/policy" >}}) page for additional details about the Policy API managed by the Policy Framework
+View the [Policy API]({{< ref "docs/getting-started/integration/policy" >}}) page for additional details about the Policy API managed by the Policy Framework
 components, including:
 
-- [`Policy`]({{< ref "docs/concepts/policy#policy" >}})
-- [`PolicySet`]({{< ref "docs/concepts/policy#policyset" >}})
-- [`PlacementBinding`]({{< ref "docs/concepts/policy#placementbinding" >}})
+- [`Policy`]({{< ref "docs/getting-started/integration/policy#policy" >}})
+- [`PolicySet`]({{< ref "docs/getting-started/integration/policy#policyset" >}})
+- [`PlacementBinding`]({{< ref "docs/getting-started/integration/policy#placementbinding" >}})
 
 ## Architecture
 

--- a/content/en/docs/getting-started/integration/policy.md
+++ b/content/en/docs/getting-started/integration/policy.md
@@ -1,6 +1,9 @@
 ---
 title: Policy
-weight: 9
+weight: 5
+aliases:
+  - /concepts/policy/
+  - /docs/concepts/policy/
 ---
 
 
@@ -24,8 +27,8 @@ The policy framework has the following API concepts:
   [policy controller]({{< ref "docs/getting-started/integration/policy-controllers" >}}).
 - A [`PolicySet`](#policyset) is a grouping mechanism of `Policy` objects. Compliance of all grouped `Policy` objects is
   summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its distribution is controlled by a
-  [Placement]({{< ref "docs/concepts/placement" >}}).
-- A [`PlacementBinding`](#placementbinding) binds a [Placement]({{< ref "docs/concepts/placement" >}}) to a `Policy` or `PolicySet`.
+  [Placement]({{< ref "docs/concepts/content-placement/placement" >}}).
+- A [`PlacementBinding`](#placementbinding) binds a [Placement]({{< ref "docs/concepts/content-placement/placement" >}}) to a `Policy` or `PolicySet`.
 
 The second half of the
 [KubeCon NA 2022 - OCM Multicluster App & Config Management](/kubecon-na-2022-ocm-multicluster-app-and-config-management.pdf)
@@ -37,7 +40,7 @@ A `Policy` is a grouping mechanism for _Policy Templates_ and is the smallest de
 Embedded _Policy Templates_ are distributed to applicable managed clusters and acted upon by the appropriate
 [policy controller]({{< ref "docs/getting-started/integration/policy-controllers" >}}). The compliance state and status of a `Policy`
 represents all embedded _Policy Templates_ in the `Policy`. The distribution of `Policy` objects is controlled by a
-[Placement]({{< ref "docs/concepts/placement" >}}).
+[Placement]({{< ref "docs/concepts/content-placement/placement" >}}).
 
 View a simple example of a `Policy` that embeds a `ConfigurationPolicy` policy template to manage a namespace called
 "prod".
@@ -96,7 +99,7 @@ doesn't exist. Other compliance types include `mustnothave` and `mustonlyhave`. 
 or see the [templating in configuration policies](#templating-in-configuration-policies) topic for advanced templating
 use cases with `ConfigurationPolicy`.
 
-When the `Policy` is bound to a [`Placement`]({{< ref "docs/concepts/placement" >}}) using a [`PlacementBinding`](#placementbinding), the
+When the `Policy` is bound to a [`Placement`]({{< ref "docs/concepts/content-placement/placement" >}}) using a [`PlacementBinding`](#placementbinding), the
 `Policy` status will report on each cluster that matches the bound `Placement`:
 
 ```yaml
@@ -125,7 +128,7 @@ kubectl get crd configurationpolicies.policy.open-cluster-management.io -o yaml
 
 ## PlacementBinding
 
-A `PlacementBinding` binds a [Placement]({{< ref "docs/concepts/placement" >}}) to a [`Policy`](#policy) or [`PolicySet`](#policyset).
+A `PlacementBinding` binds a [Placement]({{< ref "docs/concepts/content-placement/placement" >}}) to a [`Policy`](#policy) or [`PolicySet`](#policyset).
 
 Below is an example of a `PlacementBinding` that binds the `policy-namespace` `Policy` to the `placement-hub-cluster`
 `Placement`.
@@ -152,7 +155,7 @@ Once the `Policy` is bound, it will be distributed to and acted upon by the mana
 
 A `PolicySet` is a grouping mechanism of [`Policy`](#policy) objects. Compliance of all grouped `Policy` objects is
 summarized in the `PolicySet`. A `PolicySet` is a deployable unit and its distribution is controlled by a
-[Placement]({{< ref "docs/concepts/placement" >}}) when bound through a [`PlacementBinding`](#placementbinding).
+[Placement]({{< ref "docs/concepts/content-placement/placement" >}}) when bound through a [`PlacementBinding`](#placementbinding).
 
 This enables a workflow where subject matter experts write `Policy` objects and then an IT administrator creates a
 `PolicySet` that groups the previously written `Policy` objects and binds the `PolicySet` to a `Placement` that deploys

--- a/content/en/docs/scenarios/deploy-kubernetes-resources.md
+++ b/content/en/docs/scenarios/deploy-kubernetes-resources.md
@@ -22,7 +22,7 @@ we're going to use in the context.
 - __ManifestWork__: A custom resource in the hub cluster that groups a list
   of kubernetes resources together and meant for dispatching them into the
   managed cluster if the `ManifestWork` is created in a valid
-  `cluster namespace`, see details in this [page]({{< ref "docs/concepts/manifestwork" >}}).
+  `cluster namespace`, see details in this [page]({{< ref "docs/concepts/work-distribution/manifestwork" >}}).
 
 ## Deploy the resource to a target cluster
 

--- a/content/en/docs/scenarios/distribute-workload-with-placement.md
+++ b/content/en/docs/scenarios/distribute-workload-with-placement.md
@@ -33,13 +33,13 @@ And in this article, we want to show you how to use `clusteradm` to deploy
 
 Before starting with the following steps, suggest you understand the content below.
 
-- [__Placement__]({{< ref "docs/concepts/placement" >}}):
-The `Placement` API is used to dynamically select a set of [`ManagedCluster`]({{< ref "docs/concepts/managedcluster" >}})
-in one or multiple [`ManagedClusterSets`]({{< ref "docs/concepts/managedclusterset" >}})
+- [__Placement__]({{< ref "docs/concepts/content-placement/placement" >}}):
+The `Placement` API is used to dynamically select a set of [`ManagedCluster`]({{< ref "docs/concepts/cluster-inventory/managedcluster" >}})
+in one or multiple [`ManagedClusterSets`]({{< ref "docs/concepts/cluster-inventory/managedclusterset" >}})
 so that higher-level users can either replicate Kubernetes resources to the
 member clusters or run their advanced workload i.e. multi-cluster scheduling.
 
-- [__ManifestWork__]({{< ref "docs/concepts/manifestwork" >}}):
+- [__ManifestWork__]({{< ref "docs/concepts/work-distribution/manifestwork" >}}):
 A custom resource in the hub cluster that groups a list of Kubernetes resources
 together and is meant for dispatching them into the managed cluster if the
 `ManifestWork` is created in a valid `cluster namespace`.

--- a/content/en/docs/scenarios/extending-managed-clusters.md
+++ b/content/en/docs/scenarios/extending-managed-clusters.md
@@ -3,7 +3,7 @@ title: Extending managed clusters with custom attributes
 weight: 1
 ---
 
-Under some cases we need a convenient way to extend OCM's [Managed Cluster]({{< ref "docs/concepts/managedcluster" >}})
+Under some cases we need a convenient way to extend OCM's [Managed Cluster]({{< ref "docs/concepts/cluster-inventory/managedcluster" >}})
 data model so that our own custom multi-cluster system can easily work over the
 OCM's native cluster api otherwise we will have to maintain an additional
 Kubernetes' [CustomResourceDefinition](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/)
@@ -112,6 +112,6 @@ cluster frequently. e.g.:
 ## Next
 
 After extending your "Managed Cluster" with customized attributes, now we can
-try the advanced cluster selection using the [placement]({{< ref "docs/concepts/placement" >}})
+try the advanced cluster selection using the [placement]({{< ref "docs/concepts/content-placement/placement" >}})
 policies, which is provided ny another module of OCM helpful for building your
 own advanced multi-cluster systems.

--- a/content/en/docs/scenarios/integration-with-argocd.md
+++ b/content/en/docs/scenarios/integration-with-argocd.md
@@ -9,7 +9,7 @@ In this article, we want to show you how to integrate Argo CD with OCM and deplo
 
 Before starting with the following steps, we suggest you understand the content below:
 - [Argo CD ApplicationSet](https://argo-cd.readthedocs.io/en/stable/user-guide/application-set/). It adds Application automation and seeks to improve multi-cluster support and cluster multitenant support within Argo CD.
-- [OCM Placement API]({{< ref "docs/concepts/placement" >}}). It is used to dynamically select a set of [ManagedClusters]({{< ref "docs/concepts/managedcluster" >}}) in one or multiple [ManagedClusterSets]({{< ref "docs/concepts/managedclusterset" >}}) so that the workloads can be deployed to these clusters.
+- [OCM Placement API]({{< ref "docs/concepts/content-placement/placement" >}}). It is used to dynamically select a set of [ManagedClusters]({{< ref "docs/concepts/cluster-inventory/managedcluster" >}}) in one or multiple [ManagedClusterSets]({{< ref "docs/concepts/cluster-inventory/managedclusterset" >}}) so that the workloads can be deployed to these clusters.
 
 The first half of the
 [KubeCon NA 2022 - OCM Multicluster App & Config Management](/kubecon-na-2022-ocm-multicluster-app-and-config-management.pdf)


### PR DESCRIPTION
More and more fields and operations are added to OCM, like rollout strategy, placement strategy, addon template, manfestworkreplicaset, etc, they are all mixed in the existing "Concept" section. This increases the mental load for OCM beginners, and makes users confused about like, addon vs manifestwork, addon-framework vs addon template. 

- Concept: 
  - From @mikeshng: surface our core concepts: "Cluster Inventory", "Work Distribution", "Content Placement", "Add-On Extensibility"
  - concept should focus on what it is and how it works, the relationship between the key concepts. For example, what is ManagedCluster, how to register it to the hub, and how the cert rotates. The complex operations should move to quick start or use scenarios.

  move policy and control plan to quick start -> addon & integrations

- Quick Start: move the complex operations like "rollout strategy", and "placement strategy" to Quick Start.

- Some content not covered in our website yet, like FAQ, ~API changes and supported versions~, ~new experimental features~, etc. 

- confirm with @xuezhaojun for the version-controlled website. 

List a few of my though to discuss. Feel free to leave comments. 

-----

The work will be traced by https://github.com/open-cluster-management-io/ocm/issues/781. 
This PR will only surface our core concepts and Move policy and control plan to quick start
<img width="889" alt="Screenshot 2024-12-27 at 12 20 35" src="https://github.com/user-attachments/assets/b07a1edc-5a88-461a-97ab-9f84cd97130d" />
.
<img width="1023" alt="Screenshot 2024-12-27 at 12 21 15" src="https://github.com/user-attachments/assets/869c0868-067a-4a4c-92f8-45f361117b23" />

<img width="1380" alt="Screenshot 2024-12-27 at 12 21 23" src="https://github.com/user-attachments/assets/120075eb-894f-4b88-b980-7c6a827e65b1" />

