### PR TITLE
Update the policy `governance-policy-propagator` to make sure it can start

### DIFF
--- a/content/en/getting-started/integration/policy-framework.md
+++ b/content/en/getting-started/integration/policy-framework.md
@@ -128,6 +128,19 @@ Ensure `clusteradm` CLI is installed and is at least v0.3.0. Download and extrac
 
    # Deploy the policy-propagator
    kubectl apply -f ${GIT_PATH}/operator.yaml -n ${HUB_NAMESPACE}
+
+   # Choose either of the following two options to ensure the policy-propagator runs properly
+
+   # Optional 1: Enable the webhook
+   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+   kubectl apply -f ${GIT_PATH}/webhook.yaml -n ${HUB_NAMESPACE}
+
+   # Optional 2: Disable the webhook with `--enable-webhooks=false` argument
+   kubectl patch deployment governance-policy-propagator --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--enable-webhooks=false"}]' -n ${HUB_NAMESPACE}
+   kubectl patch deployment governance-policy-propagator --type='json' -p='[
+    {"op": "remove", "path": "/spec/template/spec/containers/0/volumeMounts/0"},
+    {"op": "remove", "path": "/spec/template/spec/volumes/0"} 
+    ]' -n ${HUB_NAMESPACE}
    ```
 
 2. Ensure the pods are running on the hub with the following command:


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

I tried to install the policy propagator from the source on [this page](https://open-cluster-management.io/getting-started/integration/policy-framework/). But the controller `governance-policy-propagator` failed to start with the following error message: 
```bash
oc describe pod governance-policy-propagator-78dccd9b9f-v5qhq -n open-cluster-management
 ...
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason       Age                 From               Message
  ----     ------       ----                ----               -------
  Normal   Scheduled    38m                 default-scheduler  Successfully assigned open-cluster-management/governance-policy-propagator-78dccd9b9f-v5qhq to hub1-control-plane
  Warning  FailedMount  87s (x26 over 38m)  kubelet            MountVolume.SetUp failed for volume "cert" : secret "propagator-webhook-server-cert" not found
```

Reference: https://github.com/open-cluster-management-io/governance-policy-propagator/issues/226