### PR TITLE
config policy controller crashed without resource `OperatorPolicy`

### DIFF
--- a/content/en/getting-started/integration/policy-controllers/configuration-policy.md
+++ b/content/en/getting-started/integration/policy-controllers/configuration-policy.md
@@ -68,6 +68,7 @@ Ensure `clusteradm` CLI is installed and is newer than v0.3.0. Download and extr
    export COMPONENT="config-policy-controller"
    export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/${COMPONENT}/v0.12.0/deploy"
    kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_configurationpolicies.yaml
+   kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_operatorpolicies.yaml
 
    # Set the managed cluster name
    export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

The `config-policy-controller` pod constantly crashed with error message: 
```bash
$ oc logs config-policy-controller-574cb79566-zcpzd -n open-cluster-management-agent-addon
2024-06-05T10:01:38.380Z        info    setup   config-policy-controller/main.go:66     Using   {"OperatorVersion": "0.0.1", "GoVersion": "go1.21.10", "GOOS": "linux", "GOARCH": "amd64"}
2024-06-05T10:01:38.381Z        lvl-2   setup   config-policy-controller/main.go:223    Configured the watch namespace  {"watchNamespace": "managed"}
2024-06-05T10:01:38.399Z        error   setup   config-policy-controller/main.go:295    Unable to start manager {"error": "failed to determine if *v1beta1.OperatorPolicy is namespaced: failed to get restmapping: no matches for kind \"OperatorPolicy\" in group \"policy.open-cluster-management.io\""}
main.main
        /go/src/github.com/open-cluster-management/config-policy-controller/main.go:295
runtime.main
        /usr/local/go/src/runtime/proc.go:267
```