### PR TITLE
Remove hugo wrapper.

### DIFF
--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.119.0'
       - name: build
         run: make publish
       - name: deploy

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -14,5 +14,9 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.119.0'
       - name: build
         run: make static

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,19 @@
-  
 URL := http://localhost:1313
 OPEN_CMD := $(shell command -v open || command -v xdg-open || echo : 2>/dev/null)
-HUGO_VERSION := v0.71.0
 
-hugo:
-	@echo Downloading hugo wrapper 
-	@curl -L -o hugo https://github.com/khos2ow/hugo-wrapper/releases/download/v1.4.0/hugow
-	@@chmod +x hugo
-	@./hugo --get-version $(HUGO_VERSION)
+ensurehugo:
+	@which hugo > /dev/null || (echo "Hugo not found. Please install it from https://gohugo.io/getting-started/installing/"; exit 1)
 
-server: hugo
+server: ensurehugo
 	(sleep 2; $(OPEN_CMD) $(URL)) &
-	./hugo server
+	hugo server
 
-static: hugo
-	./hugo -D -d output
+static: ensurehugo
+	hugo -D -d output
 
 publish: static
 	./deploy.sh
 
-.DEFAULT_GOAL := static 
+.DEFAULT_GOAL := static
 
 .PHONY: static server


### PR DESCRIPTION
The [hugo-wrapper](https://github.com/khos2ow/hugo-wrapper) has been inactive for years. 

Recently, when I use Apple Silicon laptop to run `make server`, it returns error:

```
(sleep 2; /usr/bin/open http://localhost:1313) &
./hugo server
Error: Unknown OS type or architecture
```

So change to let developer install hugo by themselves, and using a [active github action(1.5k starts and last update is 2 month ago)](https://github.com/peaceiris/actions-hugo) to setup hugo in github workflow