### PR TITLE
Remove "install from source" doc for GRC

### DIFF
--- a/content/en/docs/getting-started/integration/policy-controllers/configuration-policy.md
+++ b/content/en/docs/getting-started/integration/policy-controllers/configuration-policy.md
@@ -44,59 +44,12 @@ Ensure `clusteradm` CLI is installed and is newer than v0.3.0. Download and extr
    config-policy-controller-7f8fb64d8c-pmfx4          1/1     Running   0          44s
    ```
 
-### Deploy from source
-
-1. Deploy the `config-policy-controller` to the managed cluster with the following commands:
-
-   ```Shell
-   # The context name of the clusters in your kubeconfig
-   # If the clusters are created by KinD, then the context name will the follow the pattern "kind-<cluster name>".
-   export CTX_HUB_CLUSTER=<your hub cluster context>           # export CTX_HUB_CLUSTER=kind-hub
-   export CTX_MANAGED_CLUSTER=<your managed cluster context>   # export CTX_MANAGED_CLUSTER=kind-cluster1
-
-   # Configure kubectl to point to the managed cluster
-   kubectl config use-context ${CTX_MANAGED_CLUSTER}
-
-   # Create the namespace for the controller
-   export MANAGED_NAMESPACE="open-cluster-management-agent-addon"
-   kubectl create ns ${MANAGED_NAMESPACE}
-
-   # Apply the CRD
-   export COMPONENT="config-policy-controller"
-   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/${COMPONENT}/v0.12.0/deploy"
-   kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_configurationpolicies.yaml
-   kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_operatorpolicies.yaml
-
-   # Set the managed cluster name
-   export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
-
-   # Deploy the controller
-   kubectl apply -f ${GIT_PATH}/operator.yaml -n ${MANAGED_NAMESPACE}
-   kubectl set env deployment/${COMPONENT} -n ${MANAGED_NAMESPACE} --containers=${COMPONENT} WATCH_NAMESPACE=${MANAGED_CLUSTER_NAME}
-   ```
-
-   - See [config-policy-controller](https://github.com/open-cluster-management-io/config-policy-controller) for more
-     information.
-
-2. Ensure the pod is running on the managed cluster with the following command:
-
-   ```Shell
-   $ kubectl get pods -n ${MANAGED_NAMESPACE}
-   NAME                                               READY   STATUS    RESTARTS   AGE
-   config-policy-controller-7f8fb64d8c-pmfx4          1/1     Running   0          44s
-   ```
-
 ## Sample configuration policy
 
-After a successful deployment, test the policy framework and configuration policy controller with a sample policy. You
-can use a policy that includes a `Placement` mapping or if you installed Application management's `PlacementRule`
-support you can use either placement implementation. Perform the steps in the **Placement API** or the **Placement Rule
-API** section based on which placement API you desire to use.
+After a successful deployment, test the policy framework and configuration policy controller with a sample policy.
 
 For more information on how to use a `ConfigurationPolicy`, read the
 [`Policy` API concept section]({{< ref "docs/getting-started/integration/policy-framework#policy" >}}).
-
-### Placement API
 
 1. Run the following command to create a policy on the hub that uses `Placement`:
 
@@ -132,46 +85,7 @@ For more information on how to use a `ConfigurationPolicy`, read the
    ...
    ```
 
-### Placement Rule API
-
-**NOTE:** Skip this section if you applied the Placement API policy manifests.
-
-1. Run the following command to create a policy on the hub that uses `PlacementRule`:
-
-   ```Shell
-   # Configure kubectl to point to the hub cluster
-   kubectl config use-context ${CTX_HUB_CLUSTER}
-
-   # Apply the example policy and placement rule
-   kubectl apply -n default -f https://raw.githubusercontent.com/open-cluster-management-io/policy-collection/main/stable/CM-Configuration-Management/policy-pod.yaml
-   ```
-
-2. Update the `PlacementRule` to distribute the policy to the managed cluster with the following command (this
-   `clusterSelector` will deploy the policy to all managed clusters):
-
-   ```Shell
-   $ kubectl patch -n default placementrule.apps.open-cluster-management.io/placement-policy-pod --type=merge -p "{\"spec\":{\"clusterSelector\":{\"matchExpressions\":[]}}}"
-   placementrule.apps.open-cluster-management.io/placement-policy-pod patched
-   ```
-
-3. To confirm that the managed cluster is selected by the `PlacementRule`, run the following command:
-
-   ```Shell
-   $ kubectl get -n default placementrule.apps.open-cluster-management.io/placement-policy-pod -o yaml
-   ...
-   status:
-     decisions:
-     - clusterName: ${MANAGED_CLUSTER_NAME}
-       clusterNamespace: ${MANAGED_CLUSTER_NAME}
-   ...
-   ```
-
-### Final steps to apply the policy
-
-Perform the following steps to continue working with the policy to test the policy framework now that a placement method
-has been selected between `Placement` or `PlacementRule`.
-
-1. Enforce the policy to make the configuration policy automatically correct any misconfigurations on the managed
+5. Enforce the policy to make the configuration policy automatically correct any misconfigurations on the managed
    cluster:
 
    ```Shell
@@ -179,7 +93,7 @@ has been selected between `Placement` or `PlacementRule`.
    policy.policy.open-cluster-management.io/policy-pod patched
    ```
 
-2. After a few seconds, your policy is propagated to the managed cluster. To confirm, run the following command:
+6. After a few seconds, your policy is propagated to the managed cluster. To confirm, run the following command:
 
    ```Shell
    $ kubectl config use-context ${CTX_MANAGED_CLUSTER}
@@ -188,7 +102,7 @@ has been selected between `Placement` or `PlacementRule`.
    cluster1    default.policy-pod   enforce              Compliant          4m32s
    ```
 
-3. The missing pod is created by the policy on the managed cluster. To confirm, run the following command on the managed
+7. The missing pod is created by the policy on the managed cluster. To confirm, run the following command on the managed
    cluster:
 
    ```Shell

--- a/content/en/docs/getting-started/integration/policy-framework.md
+++ b/content/en/docs/getting-started/integration/policy-framework.md
@@ -29,21 +29,12 @@ cluster.
 - [Policy propagator](https://github.com/open-cluster-management-io/governance-policy-propagator)
 - [Policy framework addon](https://github.com/open-cluster-management-io/governance-policy-framework-addon)
 
-Note that in OCM versions newer than 0.8.x, the following controllers were consolidated into the
-[policy framework addon](https://github.com/open-cluster-management-io/governance-policy-framework-addon).
-
-- [Policy spec sync](https://github.com/open-cluster-management-io/governance-policy-spec-sync)
-- [Policy status sync](https://github.com/open-cluster-management-io/governance-policy-status-sync)
-- [Policy template sync](https://github.com/open-cluster-management-io/governance-policy-template-sync)
-
 ## Prerequisite
 
 You must meet the following prerequisites to install the policy framework:
 
 - Ensure [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) and
   [`kustomize`](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
-
-- Ensure [Golang](https://golang.org/doc/install) is installed, if you are planning to install from the source.
 
 - Ensure the `open-cluster-management` _cluster manager_ is installed. See
   [Start the control plane]({{< ref "docs/getting-started/installation/start-the-control-plane" >}}) for more information.
@@ -96,66 +87,6 @@ Ensure `clusteradm` CLI is installed and is at least v0.3.0. Download and extrac
      - [policy-propagator](https://github.com/open-cluster-management-io/governance-policy-propagator)
      - [policy-addon-controller](https://github.com/open-cluster-management-io/governance-policy-addon-controller)
 
-### Install from source
-
-1. Deploy the policy Custom Resource Definitions (CRD) and policy propagator component to the `open-cluster-management`
-   namespace on the hub cluster with the following commands:
-
-   ```Shell
-   # Configure kubectl to point to the hub cluster
-   kubectl config use-context ${CTX_HUB_CLUSTER}
-
-   # Create the namespace
-   export HUB_NAMESPACE="open-cluster-management"
-   kubectl create ns ${HUB_NAMESPACE}
-
-   # Set the hub cluster name
-   export HUB_CLUSTER_NAME="hub"
-
-   # Set the hub kubeconfig file
-   export HUB_KUBECONFIG="hub-kubeconfig"
-
-   # Apply the CRDs
-   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io/governance-policy-propagator/v0.12.0/deploy"
-   kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policies.yaml
-   kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_placementbindings.yaml
-   kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policyautomations.yaml
-   kubectl apply -f ${GIT_PATH}/crds/policy.open-cluster-management.io_policysets.yaml
-
-   # Deploy the policy-propagator
-   kubectl apply -f ${GIT_PATH}/operator.yaml -n ${HUB_NAMESPACE}
-
-2. The policy propagator manages a webhook that requires a certificate. You can either disable the webhook or deploy `cert-manager` alongside the webhook resources to ensure the policy propagator runs properly:
-
-   - Optional 1: Enable the webhook
-     ```shell
-     kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
-     kubectl apply -f ${GIT_PATH}/webhook.yaml -n ${HUB_NAMESPACE}
-     ```
-
-   - Optional 2: Disable the webhook with the `--enable-webhooks=false` argument
-     ```shell
-     kubectl patch deployment governance-policy-propagator --type='json' -p='[
-          {"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--enable-webhooks=false"}
-        ]' -n ${HUB_NAMESPACE}
-     kubectl patch deployment governance-policy-propagator --type='json' -p='[
-          {"op": "remove", "path": "/spec/template/spec/containers/0/volumeMounts/0"},
-          {"op": "remove", "path": "/spec/template/spec/volumes/0"}
-        ]' -n ${HUB_NAMESPACE}
-     ```
-
-3. Ensure the pods are running on the hub with the following command:
-
-   ```Shell
-   $ kubectl get pods -n ${HUB_NAMESPACE}
-   NAME                                                       READY   STATUS    RESTARTS   AGE
-   governance-policy-propagator-8c77f7f5f-kthvh               1/1     Running   0          94s
-   ```
-
-   - See more about the governance-policy-framework components:
-     - [policy-propagator](https://github.com/open-cluster-management-io/governance-policy-propagator)
-     - [policy-addon-controller](https://github.com/open-cluster-management-io/governance-policy-addon-controller)
-
 ## Deploy the synchronization components to the managed cluster(s)
 
 ### Deploy via Clusteradm CLI
@@ -180,69 +111,6 @@ Ensure `clusteradm` CLI is installed and is at least v0.3.0. Download and extrac
    $ kubectl get pods -n open-cluster-management-agent-addon
    NAME                                                     READY   STATUS    RESTARTS   AGE
    governance-policy-framework-addon-57579b7c-652zj         1/1     Running   0          87s
-   ```
-
-   **NOTE**: If you are using clusteradm v0.3.x or older, the pod will be called `governance-policy-framework` and have
-   a container per synchronization component (2 on a self-managed Hub, or 3 on a managed cluster).
-
-### Deploy from source
-
-1. Export the hub cluster `kubeconfig` with the following command:
-
-   For `kind` cluster:
-
-   ```Shell
-   kind get kubeconfig --name ${HUB_CLUSTER_NAME} --internal > ${HUB_KUBECONFIG}
-   ```
-
-   For non-`kind` clusters:
-
-   ```Shell
-   kubectl config view --context=${CTX_HUB_CLUSTER} --minify --flatten > ${HUB_KUBECONFIG}
-   ```
-
-2. Deploy the
-   [policy synchronization component](https://github.com/open-cluster-management-io/governance-policy-framework-addon)
-   to each managed cluster. Run the following commands:
-
-   **NOTE**: The `--disable-spec-sync` flag should be set to `true` in the `governance-policy-framework-addon` container
-   arguments when deploying the synchronization component to a hub that is managing itself.
-
-   ```Shell
-   # Set whether or not this is being deployed on the Hub
-   export DEPLOY_ON_HUB=false
-
-   # Configure kubectl to point to the managed cluster
-   kubectl config use-context ${CTX_MANAGED_CLUSTER}
-
-   # Create the namespace for the synchronization components
-   export MANAGED_NAMESPACE="open-cluster-management-agent-addon"
-   kubectl create ns ${MANAGED_NAMESPACE}
-
-   # Create the secret to authenticate with the hub
-   kubectl -n ${MANAGED_NAMESPACE} create secret generic hub-kubeconfig --from-file=kubeconfig=${HUB_KUBECONFIG}
-
-   # Apply the policy CRD
-   export GIT_PATH="https://raw.githubusercontent.com/open-cluster-management-io"
-   kubectl apply -f ${GIT_PATH}/governance-policy-propagator/v0.12.0/deploy/crds/policy.open-cluster-management.io_policies.yaml
-
-   # Set the managed cluster name and create the namespace
-   export MANAGED_CLUSTER_NAME=<your managed cluster name>  # export MANAGED_CLUSTER_NAME=cluster1
-   kubectl create ns ${MANAGED_CLUSTER_NAME}
-
-   # Deploy the synchronization component
-   export COMPONENT="governance-policy-framework-addon"
-   kubectl apply -f ${GIT_PATH}/${COMPONENT}/v0.12.0/deploy/operator.yaml -n ${MANAGED_NAMESPACE}
-   kubectl patch deployment governance-policy-framework-addon -n ${MANAGED_NAMESPACE} \
-     -p "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"governance-policy-framework-addon\",\"args\":[\"--hub-cluster-configfile=/var/run/klusterlet/kubeconfig\", \"--cluster-namespace=${MANAGED_CLUSTER_NAME}\", \"--enable-lease=true\", \"--log-level=2\", \"--disable-spec-sync=${DEPLOY_ON_HUB}\"]}]}}}}"
-   ```
-
-3. Verify that the pods are running on the managed cluster with the following command:
-
-   ```Shell
-   $ kubectl get pods -n ${MANAGED_NAMESPACE}
-   NAME                                                READY   STATUS    RESTARTS   AGE
-   governance-policy-framework-addon-6474b6d898-tmkw6  1/1     Running   0          2m14s
    ```
 
 ## What is next


### PR DESCRIPTION
The commands are difficult to maintain and error-prone.

Also removes references to the *-sync controllers and some PlacementRule references.