### PR TITLE
Redirect manifestwork old path to new path

### DIFF
--- a/content/en/docs/concepts/manifestwork.md
+++ b/content/en/docs/concepts/manifestwork.md
@@ -1,6 +1,8 @@
 ---
 title: ManifestWork
 weight: 6
+aliases:
+  - /concepts/manifestwork/
 ---
 
 


### PR DESCRIPTION
Fix the old path used in https://multicluster.sigs.k8s.io/concepts/work-api/. 