### PR TITLE
remove extra shell command from copy paste block for work.yaml

### DIFF
--- a/content/en/docs/scenarios/distribute-workload-with-placement.md
+++ b/content/en/docs/scenarios/distribute-workload-with-placement.md
@@ -114,7 +114,6 @@ to prepare an environment.
     The `work.yaml` contains kubernetes resource definitions, for sample:
 
     ```shell
-    $ cat work.yaml
     apiVersion: v1
     kind: ServiceAccount
     metadata:


### PR DESCRIPTION
there was a cat work.yaml in the block you copy and paste which breaks the yaml when using it. 