### PR TITLE
Add redirect for Helm charts to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,5 @@ Your changes will be verified by CI. Check the job results for details of any er
 
 ## Special Note
 
-We're also using the website to redirect requests targeting `open-cluster-management.io` to `github.com/open-cluster-management-io`, you can find more details in this [PR](https://github.com/open-cluster-management-io/open-cluster-management-io.github.io/pull/430).
-
-If allows developers to use commands like `go get open-cluster-management.io/<repo>` and also use `open-cluster-management.io/<repo>` as the import path in go.mod.
+- We're using the website to redirect requests targeting `open-cluster-management.io` to `github.com/open-cluster-management-io`, you can find more details in this [PR](https://github.com/open-cluster-management-io/open-cluster-management-io.github.io/pull/430). If allows developers to use commands like `go get open-cluster-management.io/<repo>` and also use `open-cluster-management.io/<repo>` as the import path in go.mod.
+- We're using the website to redirect requests targeting `open-cluster-management.io/helm-charts` to `github.com/open-cluster-management-io/helm-charts`, you can find more details in this [PR](https://github.com/open-cluster-management-io/open-cluster-management-io.github.io/pull/453).

--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Your changes will be verified by CI. Check the job results for details of any er
 
 ## Special Note
 
-- We're using the website to redirect requests targeting `open-cluster-management.io` to `github.com/open-cluster-management-io`, you can find more details in this [PR](https://github.com/open-cluster-management-io/open-cluster-management-io.github.io/pull/430). If allows developers to use commands like `go get open-cluster-management.io/<repo>` and also use `open-cluster-management.io/<repo>` as the import path in go.mod.
+- We're using the website to redirect requests targeting `open-cluster-management.io` to `github.com/open-cluster-management-io`, you can find more details in this [PR](https://github.com/open-cluster-management-io/open-cluster-management-io.github.io/pull/430). It allows developers to use commands like `go get open-cluster-management.io/<repo>` and also use `open-cluster-management.io/<repo>` as the import path in go.mod.
 - We're using the website to redirect requests targeting `open-cluster-management.io/helm-charts` to `github.com/open-cluster-management-io/helm-charts`, you can find more details in this [PR](https://github.com/open-cluster-management-io/open-cluster-management-io.github.io/pull/453).


### PR DESCRIPTION
Update README to include a note about redirecting requests for open-cluster-management.io/helm-charts to the GitHub repository

Related PR: https://github.com/open-cluster-management-io/helm-charts/pull/20