### PR TITLE
add scarf pixel to website

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -45,7 +45,7 @@
 }
 
 // Highlight the version release menu item
-.td-navbar .navbar-nav .nav-item:first-child .nav-link {
+.td-navbar .navbar-nav .nav-item:nth-child(2) .nav-link {
   background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
   color: white !important;
   border-radius: 20px;
@@ -56,7 +56,7 @@
   box-shadow: 0 2px 6px rgba(99, 102, 241, 0.3);
 }
 
-.td-navbar .navbar-nav .nav-item:first-child .nav-link:hover {
+.td-navbar .navbar-nav .nav-item:nth-child(2).nav-link:hover {
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(99, 102, 241, 0.4);
   background: linear-gradient(135deg, #7c3aed 0%, #a855f7 100%);

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -64,8 +64,13 @@ outputs:
 
 menu:
   main:
-    - identifier: v1.0.0-released
+    - identifier: scarf-tracker
       weight: 1
+      name: ""
+      url: "/"
+      pre: '<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=94243eae-daeb-494c-a300-099ab02c56f5" />'
+    - identifier: v1.0.0-released
+      weight: 2
       name: "🎉 v1.0.0 Released!"
       url: "/docs/release/#100-20-june-2025"
     - identifier: Github


### PR DESCRIPTION
Add a scarf pixel to the website to provide high-level web traffic insights for project maintainers so they can better understand how docs are being read and used. 

Scarf doesn't store any personally identifiable information and is GDPR and SOC 2 Type 2 compliant, as well as "approved" for use by LF and CNCF and Apache.